### PR TITLE
Add support for Imagick by subclass WP_Image_Editor_Imagick

### DIFF
--- a/inc/class-s3-uploads-image-editor-imagick.php
+++ b/inc/class-s3-uploads-image-editor-imagick.php
@@ -1,0 +1,36 @@
+<?php
+
+class S3_Uploads_Image_Editor_Imagick extends WP_Image_Editor_Imagick {
+
+	/**
+	 * Imagick by default can't handle s3:// paths
+	 * for saving images. We have instead save it to a file file,
+	 * then copy it to the s3:// path as a workaround.
+	 */
+	protected function _save( $image, $filename = null, $mime_type = null ) {
+		list( $filename, $extension, $mime_type ) = $this->get_output_format( $filename, $mime_type );
+
+		if ( ! $filename )
+			$filename = $this->generate_filename( null, null, $extension );
+
+		$upload_dir = wp_upload_dir();
+
+		if ( strpos( $filename, $upload_dir['basedir'] ) === 0 ) {
+			$temp_filename = tempnam( get_temp_dir(), 's3-uploads' );
+		}
+
+		$save = parent::_save( $image, $temp_filename, $mime_type );
+
+		if ( ! is_wp_error( $save ) ) {
+			copy( $temp_filename, $filename );
+		}
+
+		return array(
+			'path'      => $filename,
+			'file'      => wp_basename( apply_filters( 'image_make_intermediate_size', $filename ) ),
+			'width'     => $this->size['width'],
+			'height'    => $this->size['height'],
+			'mime-type' => $mime_type,
+		);
+	}
+}

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -113,6 +113,9 @@ class S3_Uploads {
 			unset($editors[$position]);
 		}
 
+		require_once dirname( __FILE__ ) . '/class-s3-uploads-image-editor-imagick.php';
+		array_unshift( $editors, 'S3_Uploads_Image_Editor_Imagick' );
+
 		return $editors;
 	}
 

--- a/tests/test-s3-uploads-image-editor-imagick.php
+++ b/tests/test-s3-uploads-image-editor-imagick.php
@@ -1,10 +1,59 @@
 <?php
 
-class S3_Uploads_Image_Editor_Imagick extends WP_UnitTestCase {
+class Test_S3_Uploads_Image_Editor_Imagick extends WP_UnitTestCase {
 
+	public function setUp() {
+		$this->image_path = dirname( __FILE__ ) . '/data/canola.jpg';
+
+		require_once ABSPATH . WPINC . '/class-wp-image-editor.php';
+		require_once ABSPATH . WPINC . '/class-wp-image-editor-imagick.php';
+
+		if ( ! WP_Image_Editor_Imagick::test() ) {
+			$this->markTestSkipped( 'WP_Image_Editor_Imagick test failed' );
+		}
+	}
 	public function test_s3_upload_image_editor_is_present() {
 		$editors = apply_filters( 'wp_image_editors', array( 'WP_Image_Editor_Imagick', 'WP_Image_Editor_GD' ) );
 
 		$this->assertFalse( in_array( 'WP_Image_Editor_Imagick', $editors ), 'Imagick editor should be removed from the image editors array.' );
+	}
+
+	/**
+	 * It's expected that we can't save image uses imagick built in, as
+	 * the undlaying system library can't write to the "s3://" filesystem.
+	 *
+	 */
+	public function test_save_image_with_inbuilt_fails() {
+
+		$upload_dir = wp_upload_dir();
+		$path = $upload_dir['basedir'] . '/canola.jpg';
+		copy( $this->image_path, $path );
+
+		$image_editor = new WP_Image_Editor_Imagick( $path );
+
+		$image_editor->load();
+		$status = $image_editor->save( $upload_dir['basedir'] . '/canola-100x100.jpg' );
+
+		$this->assertWPError( $status );
+	}
+
+	public function test_save_image() {
+
+		$upload_dir = wp_upload_dir();
+		$path = $upload_dir['basedir'] . '/canola.jpg';
+		copy( $this->image_path, $path );
+
+		$image_editor = new S3_Uploads_Image_Editor_Imagick( $path );
+
+		$image_editor->load();
+		$image_editor->resize( 100, 100, true );
+		$status = $image_editor->save( $upload_dir['basedir'] . '/canola-100x100.jpg' );
+
+		$this->assertNotInstanceOf( 'WP_Error', $status );
+
+		$this->assertEquals( $upload_dir['basedir'] . '/canola-100x100.jpg', $status['path'] );
+		$this->assertEquals( 'canola-100x100.jpg', $status['file'] );
+		$this->assertEquals( 100, $status['width'] );
+		$this->assertEquals( 100, $status['height'] );
 	}
 }


### PR DESCRIPTION
We have to provide a custom save method as imagick can't handle saving to
s3:// urls