### PR TITLE
Add filter for modifying S3 Object Paramaters

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ wp s3-uploads upload-directory <from> <to> [--sync] [--dry-run]
 
 Passing `--sync` will only upload files that are newer in `<from>` or that don't exist on S3 already. Use `--dry-run` to test.
 
-There is also an all purpose `cp` command for arbitraty copying to and from S3.
+There is also an all purpose `cp` command for arbitrary copying to and from S3.
 
 ```
 wp s3-uploads cp <from> <to>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ wp s3-uploads create-iam-user --admin-key=<key> --admin-secret=<secret>
 
 This will provide you with a new Access Key and Secret Key which you can configure S3-Uploads with. Paste the values in the `wp-config.php`. Once you have migrated your media to S3 with any of the below methods, you'll want to enable S3 Uploads: `wp s3-uploads enable`.
 
-If you want to create your IAM user yourself, or attach the neccessary permissions to an existing user, you can output the policy via `wp s3-uploads generate-iam-policy` 
+If you want to create your IAM user yourself, or attach the neccessary permissions to an existing user, you can output the policy via `wp s3-uploads generate-iam-policy`
 
 Migrating your Media to S3
 ==========
@@ -61,10 +61,30 @@ wp s3-uploads upload-directory <from> <to> [--sync] [--dry-run]
 
 Passing `--sync` will only upload files that are newer in `<from>` or that don't exist on S3 already. Use `--dry-run` to test.
 
-There is also an all purpose `cp` command for arbitraty copying to and from S3. 
+There is also an all purpose `cp` command for arbitraty copying to and from S3.
 
 ```
 wp s3-uploads cp <from> <to>
 ```
 
 Note: as either `<from>` or `<to>` can be S3 or local locations, you must speficy the full S3 location via `s3://mybucket/mydirectory` for example `cp ./test.txt s3://mybucket/test.txt`.
+
+Cache Control
+==========
+
+You can define the default HTTP `Cache-Control` header for uploaded media using the
+following constant:
+
+```PHP
+define( 'S3_UPLOADS_CACHE_CONTROL', 30 * 24 * 60 * 60 );
+	// will expire in 30 days time
+```
+
+You can also configure the `Expires` header using the `S3_UPLOADS_EXPIRES` constant
+For instance if you wanted to set an asset to effectively not expire, you could
+set the Expires header way off in the future.  For example:
+
+```PHP
+define( 'S3_UPLOADS_EXPIRES', gmdate( 'D, d M Y H:i:s', time() + (10 * 365 * 24 * 60 * 60) ) .' GMT' );
+	// will expire in 10 years time
+```

--- a/inc/class-s3-uploads-stream-wrapper.php
+++ b/inc/class-s3-uploads-stream-wrapper.php
@@ -20,6 +20,22 @@ class S3_Uploads_Stream_Wrapper extends Aws\S3\StreamWrapper {
 	// Override
 	public function stream_flush() {
 
+		// Add some HTTP headers which can be defined in wp-config.php
+
+		// Expires:
+		if ( defined( 'S3_UPLOADS_EXPIRES' ) ) {
+			$this->params[ 'Expires' ] = S3_UPLOADS_EXPIRES;
+		}
+
+		// Cache-Control:
+		if ( defined( 'S3_UPLOADS_CACHE_CONTROL' ) ) {
+			if ( is_numeric( S3_UPLOADS_CACHE_CONTROL ) ) {
+				$this->params[ 'CacheControl' ] = 'max-age='. S3_UPLOADS_CACHE_CONTROL;
+			} else {
+				$this->params[ 'CacheControl' ] = S3_UPLOADS_CACHE_CONTROL;
+			}
+		}
+
 		// Theses are the parameters passed to S3Client::putObject()
 		// http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.S3.S3Client.html#_putObject
 		$this->params = apply_filters( 's3_uploads_putObject_params', $this->params );

--- a/inc/class-s3-uploads-stream-wrapper.php
+++ b/inc/class-s3-uploads-stream-wrapper.php
@@ -17,6 +17,17 @@ class S3_Uploads_Stream_Wrapper extends Aws\S3\StreamWrapper {
 		static::$client = $client;
 	}
 
+	// Override
+	public function stream_flush() {
+
+		// Theses are the parameters passed to S3Client::putObject()
+		// http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.S3.S3Client.html#_putObject
+		$this->params = apply_filters( 's3_uploads_putObject_params', $this->params );
+
+		parent::stream_flush();
+
+	}
+
 	public function stream_metadata( $path, $option, $value ) {
 		// not implemented
 	}

--- a/inc/class-s3-uploads-stream-wrapper.php
+++ b/inc/class-s3-uploads-stream-wrapper.php
@@ -42,6 +42,7 @@ class S3_Uploads_Stream_Wrapper extends Aws\S3\StreamWrapper {
 
 		parent::stream_flush();
 
+		return;
 	}
 
 	public function stream_metadata( $path, $option, $value ) {

--- a/inc/class-s3-uploads-stream-wrapper.php
+++ b/inc/class-s3-uploads-stream-wrapper.php
@@ -20,29 +20,31 @@ class S3_Uploads_Stream_Wrapper extends Aws\S3\StreamWrapper {
 	// Override
 	public function stream_flush() {
 
-		// Add some HTTP headers which can be defined in wp-config.php
-
-		// Expires:
-		if ( defined( 'S3_UPLOADS_EXPIRES' ) ) {
-			$this->params[ 'Expires' ] = S3_UPLOADS_EXPIRES;
+		/// Expires:
+		if ( defined( 'S3_UPLOADS_HTTP_EXPIRES' ) ) {
+			$this->params[ 'Expires' ] = S3_UPLOADS_HTTP_EXPIRES;
 		}
 
 		// Cache-Control:
-		if ( defined( 'S3_UPLOADS_CACHE_CONTROL' ) ) {
-			if ( is_numeric( S3_UPLOADS_CACHE_CONTROL ) ) {
-				$this->params[ 'CacheControl' ] = 'max-age='. S3_UPLOADS_CACHE_CONTROL;
+		if ( defined( 'S3_UPLOADS_HTTP_CACHE_CONTROL' ) ) {
+			if ( is_numeric( S3_UPLOADS_HTTP_CACHE_CONTROL ) ) {
+				$this->params[ 'CacheControl' ] = 'max-age='. S3_UPLOADS_HTTP_CACHE_CONTROL;
 			} else {
-				$this->params[ 'CacheControl' ] = S3_UPLOADS_CACHE_CONTROL;
+				$this->params[ 'CacheControl' ] = S3_UPLOADS_HTTP_CACHE_CONTROL;
 			}
 		}
 
-		// Theses are the parameters passed to S3Client::putObject()
-		// http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.S3.S3Client.html#_putObject
+		/**
+		 * Filter the parameters passed to S3
+		 * Theses are the parameters passed to S3Client::putObject()
+		 * See; http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.S3.S3Client.html#_putObject
+		 *
+		 * @param array $params S3Client::putObject paramteres.
+		 */
 		$this->params = apply_filters( 's3_uploads_putObject_params', $this->params );
 
-		parent::stream_flush();
+		return parent::stream_flush();
 
-		return;
 	}
 
 	public function stream_metadata( $path, $option, $value ) {


### PR DESCRIPTION
We wanted to set defaults on Expires and cache controls, so we added a filter so you could modify the array passed to S3 via an external plugin / drop in.

However, since Expires & Cache-Control are probably quite popular, we added support for constants to be added to wp-config with the API keys to control this without requiring an additional drop-in to configure. 