### PR TITLE
Add composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,24 @@
+{
+	"name": "humanmade/s3-uploads",
+	"description": "WordPress plugin to store uploads on S3",
+	"homepage": "https://github.com/humanmade/S3-Uploads",
+	"keywords": [
+		"wordpress"
+	],
+	"license": "GPL-2.0+",
+	"authors": [
+		{
+			"name":"Human Made Limited",
+			"email":"support@humanmade.co.uk",
+			"homepage":"http://hmn.md/"
+		}
+	],
+	"support"    : {
+			"issues": "https://github.com/humanmade/s3-uploads/issues",
+			"source": "https://github.com/humanmade/s3-uploads"
+	},
+	"type": "wordpress-plugin",
+	"require": {
+		"composer/installers": "~1.0"
+	 }
+}


### PR DESCRIPTION
This is a simple enough change, adding this file means that you can use this repo to load via composer. 

There are only a couple of things to consider with this. 

1.  Should the type be "wordpress-plugin"? Is this code really designed to be an mu-plugin or is it meant to be a plugin?
2. You can use composer to get dependancies. This means you wouldn't have to hardcode the aws-sdk into the repo and using composer to grab the latest stable version. It already seems to support composer as noted [here](https://github.com/aws/aws-sdk-php/blob/master/composer.json). But it also brings it [own dependancies](https://github.com/aws/aws-sdk-php/blob/master/composer.json#L20), so might be a pain. This might be one for future development. I know that @danielhomer was looking into this. 



