### PR TITLE
Enable the plugin via CLI

### DIFF
--- a/inc/class-s3-uploads-wp-cli-command.php
+++ b/inc/class-s3-uploads-wp-cli-command.php
@@ -365,9 +365,7 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 	 * Ensable the auto-rewriting of media links to S3
 	 */
 	public function enable( $args, $assoc_args ) {
-		if ( false === add_option( 's3_uploads_enabled', 'enabled', '', 'yes' ) ) {
-			update_option( 's3_uploads_enabled', 'enabled' );
-		}
+		update_option( 's3_uploads_enabled', 'enabled' );
 
 		WP_CLI::success( 'Media URL rewriting enabled.' );
 	}

--- a/inc/class-s3-uploads-wp-cli-command.php
+++ b/inc/class-s3-uploads-wp-cli-command.php
@@ -361,6 +361,26 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 		WP_CLI::success( sprintf( 'Successfully deleted %s', $prefix ) );
 	}
 
+	/**
+	 * Ensable the auto-rewriting of media links to S3
+	 */
+	public function enable( $args, $assoc_args ) {
+		if ( false === add_option( 's3_uploads_enabled', 'enabled', '', 'yes' ) ) {
+			update_option( 's3_uploads_enabled', 'enabled' );
+		}
+
+		WP_CLI::success( 'Media URL rewriting enabled.' );
+	}
+
+	/**
+	 * Disable the auto-rewriting of media links to S3
+	 */
+	public function disable( $args, $assoc_args ) {
+		delete_option( 's3_uploads_enabled' );
+
+		WP_CLI::success( 'Media URL rewriting disabled.' );
+	}
+
 	private function recurse_copy($src,$dst) {
 		$dir = opendir($src);
 		@mkdir($dst);

--- a/inc/class-s3-uploads-wp-cli-command.php
+++ b/inc/class-s3-uploads-wp-cli-command.php
@@ -71,7 +71,11 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 		WP_CLI::success( 'Moved all attachment to S3. If you wish to update references in your database run: ' );
 		WP_CLI::line( '' );
 
-		$old_upload_dir = S3_Uploads::get_instance()->get_original_upload_dir();
+		// Esnure things are active
+		$instance = S3_Uploads::get_instance();
+		$instance->register_stream_wrapper();
+
+		$old_upload_dir = $instance->get_original_upload_dir();
 		$upload_dir = wp_upload_dir();
 
 		WP_CLI::Line( sprintf( 'wp search-replace "%s" "%s"', $old_upload_dir['baseurl'], $upload_dir['baseurl'] ) );
@@ -85,7 +89,11 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 	 */
 	public function migrate_attachment_to_s3( $args, $args_assoc ) {
 
-		$old_upload_dir = S3_Uploads::get_instance()->get_original_upload_dir();
+		// Ensure things are active
+		$instance = S3_Uploads::get_instance();
+		$instance->register_stream_wrapper();
+
+		$old_upload_dir = $instance->get_original_upload_dir();
 		$upload_dir = wp_upload_dir();
 
 		$files = array( get_post_meta( $args[0], '_wp_attached_file', true ) );

--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -21,7 +21,7 @@ function s3_uploads_init() {
 		return;
 	}
 
-	// Make sure the plugin is enabled when autoenable is on, or in a CLI system
+	// Make sure the plugin is enabled when autoenable is on, or in a CLI system (so the migrate command works)
 	if ( ( ! defined( 'WP_CLI') || ! WP_CLI ) &&                                      // If CLI is enabled, skip our other checks
 	     ( defined( 'S3_UPLOADS_AUTOENABLE' ) && false === S3_UPLOADS_AUTOENABLE ) && // If the constant is used and set to false, skip
 	     'enabled' !== get_option( 's3_uploads_enabled' ) ) {                         // If the plugin is not enabled, skip

--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -22,9 +22,9 @@ function s3_uploads_init() {
 	}
 
 	// Make sure the plugin is enabled when autoenable is on, or in a CLI system
-	if ( ( ! defined( 'WP_CLI') || ! WP_CLI ) &&
-	     ( defined( 'S3_UPLOADS_AUTOENABLE' ) && false === S3_UPLOADS_AUTOENABLE ) &&
-	     'enabled' !== get_option( 's3_uploads_enabled' ) ) {
+	if ( ( ! defined( 'WP_CLI') || ! WP_CLI ) &&                                      // If CLI is enabled, skip our other checks
+	     ( defined( 'S3_UPLOADS_AUTOENABLE' ) && false === S3_UPLOADS_AUTOENABLE ) && // If the constant is used and set to false, skip
+	     'enabled' !== get_option( 's3_uploads_enabled' ) ) {                         // If the plugin is not enabled, skip
 		return;
 	}
 

--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -21,9 +21,8 @@ function s3_uploads_init() {
 		return;
 	}
 
-	// Make sure the plugin is enabled when autoenable is on, or in a CLI system (so the migrate command works)
-	if ( ( ! defined( 'WP_CLI') || ! WP_CLI ) &&                                      // If CLI is enabled, skip our other checks
-	     ( defined( 'S3_UPLOADS_AUTOENABLE' ) && false === S3_UPLOADS_AUTOENABLE ) && // If the constant is used and set to false, skip
+	// Make sure the plugin is enabled when autoenable is on
+	if ( ( defined( 'S3_UPLOADS_AUTOENABLE' ) && false === S3_UPLOADS_AUTOENABLE ) && // If the constant is used and set to false, skip
 	     'enabled' !== get_option( 's3_uploads_enabled' ) ) {                         // If the plugin is not enabled, skip
 		return;
 	}

--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -21,6 +21,11 @@ function s3_uploads_init() {
 		return;
 	}
 
+	// Make sure the plugin is enabled
+	if ( ( defined( 'S3_UPLOADS_AUTOENABLE' ) && false === S3_UPLOADS_AUTOENABLE ) && 'enabled' !== get_option( 's3_uploads_enabled' ) ) {
+		return;
+	}
+
 	$instance = S3_Uploads::get_instance();
 	$instance->register_stream_wrapper();
 

--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -21,8 +21,10 @@ function s3_uploads_init() {
 		return;
 	}
 
-	// Make sure the plugin is enabled
-	if ( ( defined( 'S3_UPLOADS_AUTOENABLE' ) && false === S3_UPLOADS_AUTOENABLE ) && 'enabled' !== get_option( 's3_uploads_enabled' ) ) {
+	// Make sure the plugin is enabled when autoenable is on, or in a CLI system
+	if ( ( ! defined( 'WP_CLI') || ! WP_CLI ) &&
+	     ( defined( 'S3_UPLOADS_AUTOENABLE' ) && false === S3_UPLOADS_AUTOENABLE ) &&
+	     'enabled' !== get_option( 's3_uploads_enabled' ) ) {
 		return;
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,6 +21,9 @@ if ( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
 require $test_root . '/includes/functions.php';
 
 function _manually_load_plugin() {
+	// Make sure the plugin is "enabled"
+	define( 'S3_UPLOADS_AUTOENABLE', true );
+
 	require dirname( __FILE__ ) . '/../s3-uploads.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,9 +21,6 @@ if ( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
 require $test_root . '/includes/functions.php';
 
 function _manually_load_plugin() {
-	// Make sure the plugin is "enabled"
-	define( 'S3_UPLOADS_AUTOENABLE', true );
-
 	require dirname( __FILE__ ) . '/../s3-uploads.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );


### PR DESCRIPTION
Establishes a new constant and two CLI commands for enabling/disabling the plugin's URL rewriting mechanism.

If the constant `S3_UPLOADS_AUTOENABLE` is undefined or defined and set to true, the plugin behaves as usual. If it's defined and set to `false`, then the plugin will be active, but image URLs won't automatically point to S3 until explicitly enabled.

To enable the URL rewriting, you'd fire the `wp s3-uploads enable` command that's already documented in the readme. This command will set an autoloaded option in WordPress which is checked the same time as the constant above.

So, briefly:

If the constant is undefined
... or if the constant is defined and set to true
... or if the constant is defined and set to false and the WordPress option exists and is set to 'enabled'
then the plugin will behave entirely as it does today.

The constant gives existing sites the ability to install and activate the plugin, upload media to S3, and explicitly turn on the front-end features of the system without any impact on visitors' experience with the site.

Fixes humanmade/S3-Uploads#15