### PR TITLE
Add proxy information to AWS SDK config

### DIFF
--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -147,7 +147,7 @@ class S3_Uploads {
 			$proxy_address = WP_PROXY_HOST . ':' . WP_PROXY_PORT;
 
 			if ( defined('WP_PROXY_USERNAME') && defined('WP_PROXY_PASSWORD') ) {
-				$proxy_auth = WP_PROXY_USERNAME . ':' . WP_PROXY_USERNAME . '@';
+				$proxy_auth = WP_PROXY_USERNAME . ':' . WP_PROXY_PASSWORD . '@';
 			}
 
 			$params['request.options']['proxy'] = $proxy_auth . $proxy_address;

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -142,6 +142,10 @@ class S3_Uploads {
 			$params['region'] = $this->region;
 		}
 
+		if ( defined('WP_PROXY_HOST') && defined('WP_PROXY_PORT') ) {
+			$params['request.options']['proxy'] = WP_PROXY_HOST . ':' . WP_PROXY_PORT;
+		}
+
 		$params = apply_filters( 's3_uploads_s3_client_params', $params );
 
 		$this->s3 = Aws\Common\Aws::factory( $params )->get( 's3' );

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -143,7 +143,14 @@ class S3_Uploads {
 		}
 
 		if ( defined('WP_PROXY_HOST') && defined('WP_PROXY_PORT') ) {
-			$params['request.options']['proxy'] = WP_PROXY_HOST . ':' . WP_PROXY_PORT;
+			$proxy_auth = '';
+			$proxy_address = WP_PROXY_HOST . ':' . WP_PROXY_PORT;
+
+			if ( defined('WP_PROXY_USERNAME') && defined('WP_PROXY_PASSWORD') ) {
+				$proxy_auth = WP_PROXY_USERNAME . ':' . WP_PROXY_USERNAME . '@';
+			}
+
+			$params['request.options']['proxy'] = $proxy_auth . $proxy_address;
 		}
 
 		$params = apply_filters( 's3_uploads_s3_client_params', $params );


### PR DESCRIPTION
The plugin silently fails when used behind a proxy, as it doesn't pass the proxy settings from `wp-config.php` to the AWS SDK.

To get around this, I'm currently using a small plugin that intercepts the `s3_uploads_s3_client_params` filter, checks if `WP_PROXY_HOST` and `WP_PROXY_PORT` are defined and, if so, add that information to the SDK configuration [as per the documentation](http://docs.aws.amazon.com/aws-sdk-php/v2/guide/configuration.html#using-a-proxy).

It would be great to not require an additional plugin for this, so I've included that logic in this PR in case you want to include it in the core.

Thanks!