### PR TITLE
unregister the 's3' stream wrapper if it's already registered

### DIFF
--- a/inc/class-s3-uploads-stream-wrapper.php
+++ b/inc/class-s3-uploads-stream-wrapper.php
@@ -8,6 +8,11 @@ class S3_Uploads_Stream_Wrapper extends Aws\S3\StreamWrapper {
 	 * @param S3Client $client Client to use with the stream wrapper
 	 */
 	public static function register( Aws\S3\S3Client $client) {
+		
+		if ( in_array( 's3', stream_get_wrappers() ) ) {
+                	stream_wrapper_unregister( 's3' );
+          	}
+          
 		stream_wrapper_register( 's3', __CLASS__, STREAM_IS_URL );
 		static::$client = $client;
 	}

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -67,6 +67,10 @@ class S3_Uploads {
 	 */
 	public function register_stream_wrapper() {
 		if ( defined( 'S3_UPLOADS_USE_LOCAL' ) && S3_UPLOADS_USE_LOCAL ) {
+			if ( in_array( 's3', stream_get_wrappers() ) ) {
++                		stream_wrapper_unregister( 's3' );
++          		}
+
 			require_once dirname( __FILE__ ) . '/class-s3-uploads-local-stream-wrapper.php';
 			stream_wrapper_register( 's3', 'S3_Uploads_Local_Stream_Wrapper', STREAM_IS_URL );
 		} else {

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -68,8 +68,8 @@ class S3_Uploads {
 	public function register_stream_wrapper() {
 		if ( defined( 'S3_UPLOADS_USE_LOCAL' ) && S3_UPLOADS_USE_LOCAL ) {
 			if ( in_array( 's3', stream_get_wrappers() ) ) {
-+                		stream_wrapper_unregister( 's3' );
-+          		}
+                		stream_wrapper_unregister( 's3' );
+          		}
 
 			require_once dirname( __FILE__ ) . '/class-s3-uploads-local-stream-wrapper.php';
 			stream_wrapper_register( 's3', 'S3_Uploads_Local_Stream_Wrapper', STREAM_IS_URL );


### PR DESCRIPTION
See #44.

Prevents `Warning: stream_wrapper_register(): Protocol s3:// is already defined.` messages from popping up when run via cli (e.g., `wp s3-uploads migrate-attachments`.)