### PR TITLE
Lazily load the s3 library

### DIFF
--- a/inc/class-s3-uploads-stream-wrapper.php
+++ b/inc/class-s3-uploads-stream-wrapper.php
@@ -22,7 +22,7 @@ class S3_Uploads_Stream_Wrapper extends Aws\S3\StreamWrapper {
 
 		stream_wrapper_register( 's3', __CLASS__, STREAM_IS_URL );
 	}
-		
+
 	// Override
 	public function stream_flush() {
 

--- a/inc/class-s3-uploads-stream-wrapper.php
+++ b/inc/class-s3-uploads-stream-wrapper.php
@@ -2,16 +2,23 @@
 
 class S3_Uploads_Stream_Wrapper extends Aws\S3\StreamWrapper {
 
+	protected static $s3_uploads;
 	/**
 	 * Register the 's3://' stream wrapper
 	 *
 	 * @param S3Client $client Client to use with the stream wrapper
 	 */
-	public static function register( Aws\S3\S3Client $client) {
-		stream_wrapper_register( 's3', __CLASS__, STREAM_IS_URL );
-		static::$client = $client;
-	}
+	public static function register_streamwrapper( $s3_uploads )
+	{	
+		static::$s3_uploads = $s3_uploads;
 
+		if (in_array('s3', stream_get_wrappers())) {
+			stream_wrapper_unregister('s3');
+		}
+
+		stream_wrapper_register('s3', __CLASS__, STREAM_IS_URL);
+	}
+		
 	// Override
 	public function stream_flush() {
 
@@ -163,5 +170,9 @@ class S3_Uploads_Stream_Wrapper extends Aws\S3\StreamWrapper {
 
 	public function stream_metadata( $path, $option, $value ) {
 		// not implemented
+	}
+
+	public function __construct() {
+		static::$client = static::$s3_uploads->s3();
 	}
 }

--- a/inc/class-s3-uploads-stream-wrapper.php
+++ b/inc/class-s3-uploads-stream-wrapper.php
@@ -3,20 +3,24 @@
 class S3_Uploads_Stream_Wrapper extends Aws\S3\StreamWrapper {
 
 	protected static $s3_uploads;
+
+	public function __construct() {
+		static::$client = static::$s3_uploads->s3();
+	}
+
 	/**
 	 * Register the 's3://' stream wrapper
 	 *
 	 * @param S3Client $client Client to use with the stream wrapper
 	 */
-	public static function register_streamwrapper( $s3_uploads )
-	{	
+	public static function register_streamwrapper( $s3_uploads ) {
 		static::$s3_uploads = $s3_uploads;
 
-		if (in_array('s3', stream_get_wrappers())) {
-			stream_wrapper_unregister('s3');
+		if ( in_array( 's3', stream_get_wrappers() ) ) {
+			stream_wrapper_unregister( 's3' );
 		}
 
-		stream_wrapper_register('s3', __CLASS__, STREAM_IS_URL);
+		stream_wrapper_register( 's3', __CLASS__, STREAM_IS_URL );
 	}
 		
 	// Override
@@ -170,9 +174,5 @@ class S3_Uploads_Stream_Wrapper extends Aws\S3\StreamWrapper {
 
 	public function stream_metadata( $path, $option, $value ) {
 		// not implemented
-	}
-
-	public function __construct() {
-		static::$client = static::$s3_uploads->s3();
 	}
 }

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -70,8 +70,10 @@ class S3_Uploads {
 			require_once dirname( __FILE__ ) . '/class-s3-uploads-local-stream-wrapper.php';
 			stream_wrapper_register( 's3', 'S3_Uploads_Local_Stream_Wrapper', STREAM_IS_URL );
 		} else {
-			$s3 = $this->s3();
-			S3_Uploads_Stream_Wrapper::register( $s3 );
+			require_once dirname( __FILE__ ) . '/aws-sdk/aws-autoloader.php';
+			require_once dirname( __FILE__ ) . '/class-s3-uploads-stream-wrapper.php';
+
+			S3_Uploads_Stream_Wrapper::register_streamwrapper( $this );
 			stream_context_set_option( stream_context_get_default(), 's3', 'ACL', 'public-read' );
 		}
 
@@ -123,9 +125,6 @@ class S3_Uploads {
 	 * @return Aws\S3\S3Client
 	 */
 	public function s3() {
-
-		require_once dirname( dirname( __FILE__ ) ) . '/lib/aws-sdk/aws-autoloader.php';
-		require_once dirname( __FILE__ ). '/class-s3-uploads-stream-wrapper.php';
 
 		if ( ! empty( $this->s3 ) )
 			return $this->s3;

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -70,7 +70,7 @@ class S3_Uploads {
 			require_once dirname( __FILE__ ) . '/class-s3-uploads-local-stream-wrapper.php';
 			stream_wrapper_register( 's3', 'S3_Uploads_Local_Stream_Wrapper', STREAM_IS_URL );
 		} else {
-			require_once dirname( __FILE__ ) . '/aws-sdk/aws-autoloader.php';
+			require_once dirname( dirname( __FILE__ ) ) . '/lib/aws-sdk/aws-autoloader.php';
 			require_once dirname( __FILE__ ) . '/class-s3-uploads-stream-wrapper.php';
 
 			S3_Uploads_Stream_Wrapper::register_streamwrapper( $this );


### PR DESCRIPTION
Based on existing work in the lazyload branch, this change defers the loading of the aws library functions until they are needed. Data from our production environments show this will save ~250ms per page load. 