### PR TITLE
Remove require statements that are no longer needed.

### DIFF
--- a/inc/class-s3-uploads-wp-cli-command.php
+++ b/inc/class-s3-uploads-wp-cli-command.php
@@ -311,9 +311,6 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 			$prefix = trailingslashit( str_replace( strtok( S3_UPLOADS_BUCKET, '/' ) . '/', '', S3_UPLOADS_BUCKET ) );
 		}
 
-		require_once dirname( __FILE__ ) . '/class-s3-uploads-uploadsyncbuilder.php';
-		require_once dirname( __FILE__ ) . '/class-s3-uploads-changed-files-iterator.php';
-
 		try {
 			$s3->uploadDirectory(
 				$from,

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -67,11 +67,9 @@ class S3_Uploads {
 	 */
 	public function register_stream_wrapper() {
 		if ( defined( 'S3_UPLOADS_USE_LOCAL' ) && S3_UPLOADS_USE_LOCAL ) {
-			require_once dirname( __FILE__ ) . '/class-s3-uploads-local-stream-wrapper.php';
 			stream_wrapper_register( 's3', 'S3_Uploads_Local_Stream_Wrapper', STREAM_IS_URL );
 		} else {
 			require_once dirname( dirname( __FILE__ ) ) . '/lib/aws-sdk/aws-autoloader.php';
-			require_once dirname( __FILE__ ) . '/class-s3-uploads-stream-wrapper.php';
 
 			S3_Uploads_Stream_Wrapper::register_streamwrapper( $this );
 			stream_context_set_option( stream_context_get_default(), 's3', 'ACL', 'public-read' );
@@ -165,7 +163,6 @@ class S3_Uploads {
 			unset($editors[$position]);
 		}
 
-		require_once dirname( __FILE__ ) . '/class-s3-uploads-image-editor-imagick.php';
 		array_unshift( $editors, 'S3_Uploads_Image_Editor_Imagick' );
 
 		return $editors;

--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -8,8 +8,6 @@ Version: 1.0
 Author URI: http://hmn.md
 */
 
-require_once dirname( __FILE__ ) . '/inc/class-s3-uploads.php';
-
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once dirname( __FILE__ ) . '/inc/class-s3-uploads-wp-cli-command.php';
 }


### PR DESCRIPTION
An autoloader for the plugin classes was introduced in d57dec0.

This change means that these class files do not have to be required
manually anymore.