### PR TITLE
Always require AWS Autoloader

### DIFF
--- a/inc/class-s3-uploads-wp-cli-command.php
+++ b/inc/class-s3-uploads-wp-cli-command.php
@@ -139,8 +139,6 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 	 */
 	public function create_iam_user( $args, $args_assoc ) {
 
-		require_once dirname( __FILE__ ) . '/aws-sdk/aws-autoloader.php';
-
 		if ( empty( $args_assoc['username'] ) ) {
 			$username = 's3-uploads-' . sanitize_title( home_url() );
 		} else {

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -69,8 +69,6 @@ class S3_Uploads {
 		if ( defined( 'S3_UPLOADS_USE_LOCAL' ) && S3_UPLOADS_USE_LOCAL ) {
 			stream_wrapper_register( 's3', 'S3_Uploads_Local_Stream_Wrapper', STREAM_IS_URL );
 		} else {
-			require_once dirname( dirname( __FILE__ ) ) . '/lib/aws-sdk/aws-autoloader.php';
-
 			S3_Uploads_Stream_Wrapper::register_streamwrapper( $this );
 			stream_context_set_option( stream_context_get_default(), 's3', 'ACL', 'public-read' );
 		}

--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -72,3 +72,6 @@ function s3_uploads_autoload( $class_name ) {
 }
 
 spl_autoload_register( 's3_uploads_autoload');
+
+// Require AWS Autoloader file.
+require_once dirname( __FILE__ ) . '/lib/aws-sdk/aws-autoloader.php';


### PR DESCRIPTION
The AWS SDK includes its own autoloader. As such, we should load this
file in the plugin’s bootstrap.

Only loading the autoloader file when needed leads to little gains, but
it results in bugs. This changes fixes #60.