### PR TITLE
Check for PHP version requirements

### DIFF
--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -15,6 +15,10 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 add_action( 'plugins_loaded', 's3_uploads_init' );
 
 function s3_uploads_init() {
+	if ( ! s3_uploads_check_requirements() ) {
+		return;
+	}
+
 	if ( ! defined( 'S3_UPLOADS_BUCKET' ) ) {
 		return;
 	}
@@ -29,6 +33,34 @@ function s3_uploads_init() {
 
 	$instance = S3_Uploads::get_instance();
 	$instance->setup();
+}
+
+/**
+ * Check whether the environment meets the plugin's requirements, like the minimum PHP version.
+ *
+ * @return bool True if the requirements are met, else false.
+ */
+function s3_uploads_check_requirements() {
+	if ( version_compare( '5.3.3', PHP_VERSION, '>=' ) ) {
+		if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
+			add_action( 'admin_notices', 's3_uploads_outdated_php_version_notice' );
+		}
+
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Print an admin notice when the PHP version is not high enough.
+ *
+ * This has to be a named function for compatibility with PHP 5.2.
+ */
+function s3_uploads_outdated_php_version_notice() {
+	printf( '<div class="error"><p>The S3 Uploads plugin requires PHP version 5.3.3 or higher. Your server is running PHP version %s.</p></div>',
+		PHP_VERSION
+	);
 }
 
 /**


### PR DESCRIPTION
Add a notice when the requirements are not met, and return to avoid
executing the rest of the plugin.

Fixes #69.