### PR TITLE
Missing installation step added to README.md file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ define( 'S3_UPLOADS_KEY', '' );
 define( 'S3_UPLOADS_SECRET', '' );
 ```
 
+You must then enable the plugin. To do this via WP-CLI use command:
+
+```
+wp plugin activate S3-Uploads
+```
+
 The next thing that you should do is to verify your setup. You can do this using the `verify` command
 like so:
 


### PR DESCRIPTION
After adding the plugin files to your WordPress install you must activate the plugin before you can use the s3-uploads command line tools. 

I have added an extra step to the README.md file wit the WP-CLI activation command.


