### PR TITLE
Automation output improvement

### DIFF
--- a/inc/class-s3-uploads-wp-cli-command.php
+++ b/inc/class-s3-uploads-wp-cli-command.php
@@ -139,7 +139,7 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 	 * Create an AWS IAM user for S3 Uploads to user
 	 *
 	 * @subcommand create-iam-user
-	 * @synopsis --admin-key=<key> --admin-secret=<secret> [--username=<username>] [--automatic]
+	 * @synopsis --admin-key=<key> --admin-secret=<secret> [--username=<username>] [--format=<format>]
 	 */
 	public function create_iam_user( $args, $args_assoc ) {
 
@@ -172,9 +172,10 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 			WP_CLI::error( $e->getMessage() );
 		}
 
-        if(!empty($args_assoc['automatic']))
+        if(!empty($args_assoc['format']))
         {
-            WP_CLI\Utils\format_items('json', array((object) $credentials), array('AccessKeyId', 'SecretAccessKey'));
+            $format = $args_assoc['format']
+            WP_CLI\Utils\format_items($format, array((object) $credentials), array('AccessKeyId', 'SecretAccessKey'));
         } 
 
         else

--- a/inc/class-s3-uploads-wp-cli-command.php
+++ b/inc/class-s3-uploads-wp-cli-command.php
@@ -92,7 +92,7 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 	 * Migrate a single attachment's files to S3
 	 *
 	 * @subcommand migrate-attachment
-	 * @synopsis <attachment-id> [--delete-local]
+	 * @synopsis <attachment-id> [--delete-local] [--automatic]
 	 */
 	public function migrate_attachment_to_s3( $args, $args_assoc ) {
 
@@ -172,9 +172,17 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 			WP_CLI::error( $e->getMessage() );
 		}
 
-		WP_CLI::success( sprintf( 'Created new IAM user %s. The Access Credentials are displayed below', $username ) );
+        if(!empty($args_assoc['automatic']))
+        {
+            //WP_CLI::success(sprintf('%s'), json_encode($credentials));
+            WP_CLI\Utils\format_items('json', array((object) $credentials), array('AccessKeyId', 'SecretAccessKey'));
+        } 
 
-		WP_CLI\Utils\format_items( 'table', array( (object) $credentials ), array( 'AccessKeyId', 'SecretAccessKey' ) );
+        else
+        {
+		    WP_CLI::success( sprintf( 'Created new IAM user %s. The Access Credentials are displayed below', $username ) );
+		    WP_CLI\Utils\format_items( 'table', array( (object) $credentials ), array( 'AccessKeyId', 'SecretAccessKey' ) );
+        }
 
 	}
 

--- a/inc/class-s3-uploads-wp-cli-command.php
+++ b/inc/class-s3-uploads-wp-cli-command.php
@@ -92,7 +92,7 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 	 * Migrate a single attachment's files to S3
 	 *
 	 * @subcommand migrate-attachment
-	 * @synopsis <attachment-id> [--delete-local] [--automatic]
+	 * @synopsis <attachment-id> [--delete-local] 
 	 */
 	public function migrate_attachment_to_s3( $args, $args_assoc ) {
 
@@ -139,7 +139,7 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 	 * Create an AWS IAM user for S3 Uploads to user
 	 *
 	 * @subcommand create-iam-user
-	 * @synopsis --admin-key=<key> --admin-secret=<secret> [--username=<username>]
+	 * @synopsis --admin-key=<key> --admin-secret=<secret> [--username=<username>] [--automatic]
 	 */
 	public function create_iam_user( $args, $args_assoc ) {
 
@@ -174,7 +174,6 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 
         if(!empty($args_assoc['automatic']))
         {
-            //WP_CLI::success(sprintf('%s'), json_encode($credentials));
             WP_CLI\Utils\format_items('json', array((object) $credentials), array('AccessKeyId', 'SecretAccessKey'));
         } 
 


### PR DESCRIPTION
We are attempting to use this plugin for rolling out S3 Uploads across ~700 sites. Therefore, we need to be able to automate the installation process. This change will add a new WP CLI argument for the create-iam-user action which will result in a JSON encoded string being printed instead of the user friendly output that currently exists.