### PR TITLE
Allow bucket URL to be filtered even when defined

### DIFF
--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -118,7 +118,7 @@ class S3_Uploads {
 
 	public function get_s3_url() {
 		if ( $this->bucket_url ) {
-			return $this->bucket_url;
+			return apply_filters( 's3_uploads_bucket_url', $this->bucket_url );
 		}
 
 		$bucket = strtok( $this->bucket, '/' );


### PR DESCRIPTION
Understand this might be intentionally unfiltered so the constant is definitely constant. This just allows me to run `set_url_scheme()` on for an edge case on our hosting stack.

Worth adding `set_url_scheme()` in here anyway instead of the filter?