### PR TITLE
Update referenced file to prevent CLI error.

### DIFF
--- a/inc/class-s3-uploads-wp-cli-command.php
+++ b/inc/class-s3-uploads-wp-cli-command.php
@@ -24,7 +24,7 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 		WP_CLI::print_value( 'Attempting to upload file ' . $s3_path );
 
 		$copy = copy(
-			dirname( dirname( __FILE__ ) ) . '/tests/data/canola.jpg',
+			dirname( dirname( __FILE__ ) ) . '/tests/data/sunflower.jpg',
 			$s3_path
 		);
 


### PR DESCRIPTION
CLI verify steps bomb out now because `canola.jpg` doesn't exist, but `sunflower.jpg` does.

Fixes #117 