### PR TITLE
Clean Up IAM Policy

### DIFF
--- a/inc/class-s3-uploads-wp-cli-command.php
+++ b/inc/class-s3-uploads-wp-cli-command.php
@@ -188,39 +188,65 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 			$path = str_replace( strtok( S3_UPLOADS_BUCKET, '/' ) . '/', '', S3_UPLOADS_BUCKET );
 		}
 
-		return '{
+		return sprintf(
+			trim( '
+{
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "Stmt1392016154000",
+      "Sid": "ObjectOperationsReadWriteDelete",
       "Effect": "Allow",
+      "Resource": "arn:aws:s3:::%1$s/*",
       "Action": [
-        "s3:AbortMultipartUpload",
-        "s3:DeleteObject",
-        "s3:GetBucketAcl",
-        "s3:GetBucketLocation",
-        "s3:GetBucketPolicy",
         "s3:GetObject",
-        "s3:GetObjectAcl",
-        "s3:ListBucket",
-        "s3:ListBucketMultipartUploads",
-        "s3:ListMultipartUploadParts",
         "s3:PutObject",
-        "s3:PutObjectAcl"
-      ],
-      "Resource": [
-        "arn:aws:s3:::' . S3_UPLOADS_BUCKET . '/*"
+        "s3:GetObjectAcl",
+        "s3:PutObjectAcl",
+        "s3:DeleteObject",
+        "s3:AbortMultipartUpload",
+        "s3:ListMultipartUploadParts"
       ]
     },
     {
-      "Sid": "AllowRootAndHomeListingOfBucket",
-      "Action": ["s3:ListBucket"],
+      "Sid": "BucketOperationsListContents",
       "Effect": "Allow",
-      "Resource": ["arn:aws:s3:::' . $bucket . '"],
-      "Condition":{"StringLike":{"s3:prefix":["' . ( $path ? $path . '/' : '' ) . '*"]}}
+      "Resource": "arn:aws:s3:::%2$s",
+      "Condition": { "StringLike": {
+        "s3:prefix": [ "%3$s" ],
+        "s3:delimiter": [ "/" ]
+      } },
+      "Action": [
+        "s3:ListBucket"
+      ]
+    },
+    {
+      "Sid": "BucketSubresourceOperationsRead",
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::%2$s",
+      "Action": [
+        "s3:GetAccelerateConfiguration",
+        "s3:GetBucketAcl",
+        "s3:GetBucketCORS",
+        "s3:GetBucketVersioning",
+        "s3:GetBucketRequestPayment",
+        "s3:GetBucketLocation",
+        "s3:GetBucketPolicy",
+        "s3:GetBucketNotification",
+        "s3:GetBucketLogging",
+        "s3:GetBucketTagging",
+        "s3:GetBucketWebsite",
+        "s3:GetLifecycleConfiguration",
+        "s3:GetReplicationConfiguration"
+      ]
     }
   ]
-}';
+}
+			' ),
+			S3_UPLOADS_BUCKET,
+			$bucket,
+			( $path ? $path . '/' : '' ) . '*'
+		);
+
 	}
 
 	/**


### PR DESCRIPTION
The existing policy tries to set some bucket policies against S3 objects which is invalid per AWS docs here:
http://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html

This change sets read/write/delete permissions on all objects in the bucket / bucket and prefix if given and listing permissions for the bucket with a conditional prefix if given. All bucket sub resource operations have also been moved into a separate rule (readonly) for the bucket. I think these are might not be needed by S3-Uploads as they were not specified properly before but it seems harmless to give read permissions to the key and may be useful in the future for the plugin to trigger different actions depending on how the S3 bucket is configured.

As examples under the updated policy, here's the full policy returned when `S3_UPLOADS_BUCKET` is set to a bucket only, `static.xyu.io`:

```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "ObjectOperationsReadWriteDelete",
      "Effect": "Allow",
      "Resource": "arn:aws:s3:::static.xyu.io/*",
      "Action": [
        "s3:GetObject",
        "s3:PutObject",
        "s3:GetObjectAcl",
        "s3:PutObjectAcl",
        "s3:DeleteObject",
        "s3:AbortMultipartUpload",
        "s3:ListMultipartUploadParts"
      ]
    },
    {
      "Sid": "BucketOperationsListContents",
      "Effect": "Allow",
      "Resource": "arn:aws:s3:::static.xyu.io",
      "Condition": { "StringLike": {
        "s3:prefix": [ "*" ],
        "s3:delimiter": [ "/" ]
      } },
      "Action": [
        "s3:ListBucket"
      ]
    },
    {
      "Sid": "BucketSubresourceOperationsRead",
      "Effect": "Allow",
      "Resource": "arn:aws:s3:::static.xyu.io",
      "Action": [
        "s3:GetAccelerateConfiguration",
        "s3:GetBucketAcl",
        "s3:GetBucketCORS",
        "s3:GetBucketVersioning",
        "s3:GetBucketRequestPayment",
        "s3:GetBucketLocation",
        "s3:GetBucketPolicy",
        "s3:GetBucketNotification",
        "s3:GetBucketLogging",
        "s3:GetBucketTagging",
        "s3:GetBucketWebsite",
        "s3:GetLifecycleConfiguration",
        "s3:GetReplicationConfiguration"
      ]
    }
  ]
}
```

And when `S3_UPLOADS_BUCKET` is set to a bucket and path, `static.xyu.io/test`:

```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "ObjectOperationsReadWriteDelete",
      "Effect": "Allow",
      "Resource": "arn:aws:s3:::static.xyu.io/test/*",
      "Action": [
        "s3:GetObject",
        "s3:PutObject",
        "s3:GetObjectAcl",
        "s3:PutObjectAcl",
        "s3:DeleteObject",
        "s3:AbortMultipartUpload",
        "s3:ListMultipartUploadParts"
      ]
    },
    {
      "Sid": "BucketOperationsListContents",
      "Effect": "Allow",
      "Resource": "arn:aws:s3:::static.xyu.io",
      "Condition": { "StringLike": {
        "s3:prefix": [ "test/*" ],
        "s3:delimiter": [ "/" ]
      } },
      "Action": [
        "s3:ListBucket"
      ]
    },
    {
      "Sid": "BucketSubresourceOperationsRead",
      "Effect": "Allow",
      "Resource": "arn:aws:s3:::static.xyu.io",
      "Action": [
        "s3:GetAccelerateConfiguration",
        "s3:GetBucketAcl",
        "s3:GetBucketCORS",
        "s3:GetBucketVersioning",
        "s3:GetBucketRequestPayment",
        "s3:GetBucketLocation",
        "s3:GetBucketPolicy",
        "s3:GetBucketNotification",
        "s3:GetBucketLogging",
        "s3:GetBucketTagging",
        "s3:GetBucketWebsite",
        "s3:GetLifecycleConfiguration",
        "s3:GetReplicationConfiguration"
      ]
    }
  ]
}
```
