### PR TITLE
Separate end points in Multisite network.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,29 @@ if you want to develop offline you have a couple of options.
 Option 2 will allow you to run the S3 Uploads plugin for production parity purposes, it will essentially mock
 Amazon S3 with a local stream wrapper and actually store the uploads in your WP Upload Dir `/s3/`.
 
+New: Multisite Configuration
+=======
+For separating the endpoints of each site in the multisite network, you need to modify /inc/class-s3-uploads.php:
+```php
+	public static function get_instance() {
+
+		//load your mutlisites' information
+		$sites =  array(
+	array("id"=>"YOUR SITE BLOG ID (e.g. 1)", //"id" is the blog id of each website 
+		"key"=>"YOUR ACCESS KEY ID", //"key" is the user's Access Key Id
+		"bucket"=>"YOUR BUCKET NAME FOR THIS SITE", //"bucket" is S3 bucket name
+		"secret"=>"YOUR SECRET ACCESS KEY", //"secret" is the user's Secret Access Key
+		"region"=>"THE REGION OF THIS BUCKET"), //"region" is the corresponding bucket region 
+	array("id"=>"YOUR SITE BLOG ID (e.g. 2)",
+		"key"=>"YOUR ACCESS KEY ID",
+		"bucket"=>"YOUR BUCKET NAME FOR THIS SITE",
+		"secret"=>"YOUR SECRET ACCESS KEY",
+		"region"=>"THE REGION OF THIS BUCKET")
+	);
+
+	}
+```
+
 Credits
 =======
 Created by Human Made for high volume and large-scale sites. We run S3 Uploads on sites with millions of monthly page views, and thousands of sites.

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -16,6 +16,28 @@ class S3_Uploads {
 	 */
 	public static function get_instance() {
 
+		//load your mutlisites' information
+		//"id" is the blog id of each website
+		//"key" is the user's Access Key Id
+		//"bucket" is S3 bucket name
+		//"secret" is the user's Secret Access Key
+		//"region" is the corresponding bucket region 
+		$sites =  array(
+	array("id"=>"YOUR SITE BLOG ID (e.g. 1)",
+		"key"=>"YOUR ACCESS KEY ID",
+		"bucket"=>"YOUR BUCKET NAME FOR THIS SITE",
+		"secret"=>"YOUR SECRET ACCESS KEY",
+		"region"=>"THE REGION OF THIS BUCKET"),
+	array("id"=>"YOUR SITE BLOG ID (e.g. 2)",
+		"key"=>"YOUR ACCESS KEY ID",
+		"bucket"=>"YOUR BUCKET NAME FOR THIS SITE",
+		"secret"=>"YOUR SECRET ACCESS KEY",
+		"region"=>"THE REGION OF THIS BUCKET")
+	);
+
+        
+		//load the default end point of s3-uploads which come from your wp-config.php
+		//This will set up the default S3 end point when there is no value set in $sites
 		if ( ! self::$instance ) {
 			self::$instance = new S3_Uploads(
 				S3_UPLOADS_BUCKET,
@@ -25,6 +47,21 @@ class S3_Uploads {
 				S3_UPLOADS_REGION
 			);
 		}
+
+		//replace the default S3 endpoint by the endpoint of the current website
+		for ($i=0;$i<count($sites);$i++){
+			$thesite=$sites[$i];
+			if ($thesite['id']==get_current_blog_id()) {
+			self::$instance = new S3_Uploads(
+			$thesite['bucket'],
+			$thesite['key'],
+			$thesite['secret'],
+			null,
+			$thesite['region']
+			);
+			break;
+		    }
+	    }
 
 		return self::$instance;
 	}


### PR DESCRIPTION
I have added multisite support to separate the S3 endpoint of each subsite in a multisite network, by modifying the function get_instance(). 

User can set the endpoints of each site by modifying the /inc/class-s3-uploads.php：
```PHP
public static function get_instance() {

		//load your mutlisites' information
		$sites =  array(
	array("id"=>"YOUR SITE BLOG ID (e.g. 1)", //"id" is the blog id of each website
		"key"=>"YOUR ACCESS KEY ID", //"key" is the user's Access Key Id
		"bucket"=>"YOUR BUCKET NAME FOR THIS SITE", //"bucket" is S3 bucket name
		"secret"=>"YOUR SECRET ACCESS KEY", //"secret" is the user's Secret Access Key
		"region"=>"THE REGION OF THIS BUCKET"), //"region" is the corresponding bucket region 
	array("id"=>"YOUR SITE BLOG ID (e.g. 2)",
		"key"=>"YOUR ACCESS KEY ID",
		"bucket"=>"YOUR BUCKET NAME FOR THIS SITE",
		"secret"=>"YOUR SECRET ACCESS KEY",
		"region"=>"THE REGION OF THIS BUCKET")
	);

        .....

	}
```
