### PR TITLE
Add missing `stream_metadata()` method

### DIFF
--- a/inc/class-s3-uploads-stream-wrapper.php
+++ b/inc/class-s3-uploads-stream-wrapper.php
@@ -237,6 +237,11 @@ class S3_Uploads_Stream_Wrapper
 			});
 	}
 
+	public function stream_metadata($path, $option, $value)
+	{
+		// void
+	}
+
 	public function stream_tell()
 	{
 		return $this->boolCall(function() { return $this->body->tell(); });

--- a/inc/class-s3-uploads-stream-wrapper.php
+++ b/inc/class-s3-uploads-stream-wrapper.php
@@ -239,7 +239,7 @@ class S3_Uploads_Stream_Wrapper
 
 	public function stream_metadata($path, $option, $value)
 	{
-		// void
+		return false;
 	}
 
 	public function stream_tell()


### PR DESCRIPTION
The PR prevents at PHP Warning triggered by `_wp_handle_upload()` calling `chmod()` on the custom S3 stream wrapper.

See https://github.com/humanmade/S3-Uploads/issues/134.
