### PR TITLE
Fixing temporary upload location

### DIFF
--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -243,7 +243,7 @@ class S3_Uploads {
 	 * @return string
 	 */
 	public function copy_image_from_s3( $file ) {
-		$temp_filename = wp_tempnam( $file, 's3-uploads' );
+		$temp_filename = wp_tempnam( $file, WP_CONTENT_DIR . '/s3-uploads/' );
 		copy( $file, $temp_filename );
 		return $temp_filename;
 	}


### PR DESCRIPTION
The temporary file currently ends up in the `inc` directory as `s3-uploadsFILENAMErandom.tmp`. This doesn't work very well when the unix permissions are set to read-only for plugins. This moves things to `wp-content/s3-uploads`.