### PR TITLE
add control of S3 object permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,21 @@ By default, S3 Uploads will use the canonical S3 URIs for referencing the upload
 define( 'S3_UPLOADS_BUCKET_URL', 'https://your.origin.url.example/path' );
 ```
 
+S3 Object Permissions
+=======
+
+The object permission of files uploaded to S3 by this plugin can be controlled by setting the `S3_UPLOADS_OBJECT_ACL`
+constant. The default setting if not specified is `public-read` to allow objects to be read by anyone. If you don't
+want the uploads to be publicly readable then you can define `S3_UPLOADS_OBJECT_ACL` as one of `private` or `authenticated-read` 
+in you wp-config file:
+
+```PHP
+// Set the S3 object permission to private
+define('S3_UPLOADS_OBJECT_ACL', 'private');
+```
+
+For more information on S3 permissions please see the Amazon S3 permissions documentation.
+
 Offline Development
 =======
 

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -73,7 +73,8 @@ class S3_Uploads {
 			stream_wrapper_register( 's3', 'S3_Uploads_Local_Stream_Wrapper', STREAM_IS_URL );
 		} else {
 			S3_Uploads_Stream_Wrapper::register( $this->s3() );
-			stream_context_set_option( stream_context_get_default(), 's3', 'ACL', 'public-read' );
+			$objectAcl = defined( 'S3_UPLOADS_OBJECT_ACL' ) ? S3_UPLOADS_OBJECT_ACL : 'public-read';
+			stream_context_set_option( stream_context_get_default(), 's3', 'ACL', $objectAcl );
 		}
 
 		stream_context_set_option( stream_context_get_default(), 's3', 'seekable', true );


### PR DESCRIPTION
Allow the S3 object permissions to be controlled by use of a constant. Use case is when the WordPress contents should not be public. Existing public-read default is retained.