### PR TITLE
Allow external AWS SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
 	},
 	"type": "wordpress-plugin",
 	"require": {
-		"composer/installers": "~1.0"
+		"composer/installers": "~1.0",
+		"aws/aws-sdk-php": "~3.18"
 	 }
 }

--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -15,6 +15,12 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 add_action( 'plugins_loaded', 's3_uploads_init' );
 
 function s3_uploads_init() {
+	// Ensure the AWS SDK can be loaded.
+	if ( ! class_exists( '\\Aws\\S3\\S3Client' ) ) {
+		// Require AWS Autoloader file.
+		require_once dirname( __FILE__ ) . '/lib/aws-sdk/aws-autoloader.php';
+	}
+
 	if ( ! s3_uploads_check_requirements() ) {
 		return;
 	}
@@ -107,6 +113,3 @@ function s3_uploads_autoload( $class_name ) {
 }
 
 spl_autoload_register( 's3_uploads_autoload' );
-
-// Require AWS Autoloader file.
-require_once dirname( __FILE__ ) . '/lib/aws-sdk/aws-autoloader.php';


### PR DESCRIPTION
If the AWS SDK is already available, use it. Version compatibility is the responsibility of the user.

Additionally, when loaded via Composer, require the SDK via Composer. This allows Composer to handle version compatibility and such.

Fixes #142.