### PR TITLE
Improved S3 autoloader performance.

### DIFF
--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -97,6 +97,9 @@ function s3_uploads_enabled() {
  * @param $class_name Name of the class to load.
  */
 function s3_uploads_autoload( $class_name ) {
+	if ( strpos( $class_name, 'S3_Uploads' ) !== 0 ) {
+		return;
+	}
 	/*
 	 * Load plugin classes:
 	 * - Class name: S3_Uploads_Image_Editor_Imagick.


### PR DESCRIPTION
`s3_uploads_autoload()` was checking if a file exists for any class name passed to it. That was hurting performance in every page load.
The fix tries to recognize if the class is a S3_Uploads family