### PR TITLE
Fix command case in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Please refer to this region list http://docs.aws.amazon.com/general/latest/gr/ra
 You must then enable the plugin. To do this via WP-CLI use command:
 
 ```
-wp plugin activate S3-Uploads
+wp plugin activate s3-uploads
 ```
 
 The next thing that you should do is to verify your setup. You can do this using the `verify` command


### PR DESCRIPTION
The docs say that you should activate this plugin with the following command:

```
wp plugin activate S3-Uploads
```

It seems like wp-cli is case sensitive and the command should be:

```
wp plugin activate s3-uploads
```

This PR fixes the readme as this threw me for a few minutes while trying to get it up and running!