### PR TITLE
Multisite support

### DIFF
--- a/inc/class-s3-uploads-uploadsyncbuilder.php
+++ b/inc/class-s3-uploads-uploadsyncbuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-class S3_Uploads_UploadSyncBuilder extends Aws\S3\Sync\UploadSyncBuilder {
+class S3_Uploads_UploadSyncBuilder extends {
 
 	public function __construct( $is_dry_run = false ) {
 		$this->dry_run = $is_dry_run;

--- a/inc/class-s3-uploads-wp-cli-command.php
+++ b/inc/class-s3-uploads-wp-cli-command.php
@@ -378,7 +378,11 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 	 * Ensable the auto-rewriting of media links to S3
 	 */
 	public function enable( $args, $assoc_args ) {
-		update_option( 's3_uploads_enabled', 'enabled' );
+		if ( is_multisite() ) {
+			update_site_option( 's3_uploads_enabled', 'enabled' );
+		} else {
+			update_option( 's3_uploads_enabled', 'enabled' );
+		}
 
 		WP_CLI::success( 'Media URL rewriting enabled.' );
 	}
@@ -387,7 +391,11 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 	 * Disable the auto-rewriting of media links to S3
 	 */
 	public function disable( $args, $assoc_args ) {
-		delete_option( 's3_uploads_enabled' );
+		if ( is_multisite() ) {
+			delete_site_option( 's3_uploads_enabled' );
+		} else {
+			delete_option( 's3_uploads_enabled' );
+		}
 
 		WP_CLI::success( 'Media URL rewriting disabled.' );
 	}

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -38,7 +38,6 @@ class S3_Uploads {
 		$this->region     = $region;
 	}
 
-
 	/**
 	 * Setup the hooks, urls filtering etc for S3 Uploads
 	 */
@@ -50,7 +49,7 @@ class S3_Uploads {
 		add_filter( 'wp_delete_file', array( $this, 'wp_filter_delete_file' ) );
 		add_filter( 'wp_read_image_metadata', array( $this, 'wp_filter_read_image_metadata' ), 10, 2 );
 
-		add_filter( 'wp_calculate_image_srcset', array( $this, 'rewrite_srcset' ) );
+		add_filter( 'wp_calculate_image_srcset', array( $this, 'change_srcset' );
 
 		remove_filter( 'admin_notices', 'wpthumb_errors' );
 
@@ -67,11 +66,6 @@ class S3_Uploads {
 		remove_filter( 'wp_image_editors', array( $this, 'filter_editors' ), 9 );
 		remove_filter( 'wp_handle_sideload_prefilter', array( $this, 'filter_sideload_move_temp_file_to_s3' ) );
 		remove_filter( 'wp_delete_file', array( $this, 'wp_filter_delete_file' ) );
-		remove_filter( 'wp_calculate_image_srcset', array( $this, 'rewrite_srcset' ) );
-	}
-
-	public function rewrite_srcset($sources) {
-		var_dump($this->get_s3_url());
 	}
 
 	/**

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -38,6 +38,7 @@ class S3_Uploads {
 		$this->region     = $region;
 	}
 
+
 	/**
 	 * Setup the hooks, urls filtering etc for S3 Uploads
 	 */
@@ -48,6 +49,9 @@ class S3_Uploads {
 		add_filter( 'wp_image_editors', array( $this, 'filter_editors' ), 9 );
 		add_filter( 'wp_delete_file', array( $this, 'wp_filter_delete_file' ) );
 		add_filter( 'wp_read_image_metadata', array( $this, 'wp_filter_read_image_metadata' ), 10, 2 );
+
+		add_filter( 'wp_calculate_image_srcset', array( $this, 'rewrite_srcset' ) );
+
 		remove_filter( 'admin_notices', 'wpthumb_errors' );
 
 		add_action( 'wp_handle_sideload_prefilter', array( $this, 'filter_sideload_move_temp_file_to_s3' ) );
@@ -63,6 +67,11 @@ class S3_Uploads {
 		remove_filter( 'wp_image_editors', array( $this, 'filter_editors' ), 9 );
 		remove_filter( 'wp_handle_sideload_prefilter', array( $this, 'filter_sideload_move_temp_file_to_s3' ) );
 		remove_filter( 'wp_delete_file', array( $this, 'wp_filter_delete_file' ) );
+		remove_filter( 'wp_calculate_image_srcset', array( $this, 'rewrite_srcset' ) );
+	}
+
+	public function rewrite_srcset($sources) {
+		var_dump($this->get_s3_url());
 	}
 
 	/**

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -49,8 +49,6 @@ class S3_Uploads {
 		add_filter( 'wp_delete_file', array( $this, 'wp_filter_delete_file' ) );
 		add_filter( 'wp_read_image_metadata', array( $this, 'wp_filter_read_image_metadata' ), 10, 2 );
 
-		add_filter( 'wp_calculate_image_srcset', array( $this, 'change_srcset' );
-
 		remove_filter( 'admin_notices', 'wpthumb_errors' );
 
 		add_action( 'wp_handle_sideload_prefilter', array( $this, 'filter_sideload_move_temp_file_to_s3' ) );

--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -4,7 +4,7 @@
 Plugin Name: S3 Uploads
 Description: Store uploads in S3
 Author: Human Made Limited
-Version: 2.0.0-beta2
+Version: 2.0.0-beta3
 Author URI: http://hmn.md
 */
 

--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -78,7 +78,14 @@ function s3_uploads_enabled() {
 	// Make sure the plugin is enabled when autoenable is on
 	$constant_autoenable_off = ( defined( 'S3_UPLOADS_AUTOENABLE' ) && false === S3_UPLOADS_AUTOENABLE );
 
-	if ( $constant_autoenable_off && 'enabled' !== get_option( 's3_uploads_enabled' ) ) {                         // If the plugin is not enabled, skip
+	$s3_uploads_enabled = '';
+	if ( is_multisite() ) {
+		$s3_uploads_enabled = get_site_option( 's3_uploads_enabled' );
+	} else {
+		$s3_uploads_enabled = get_option( 's3_uploads_enabled' );
+	}
+
+	if ( $constant_autoenable_off && 'enabled' !==  $s3_uploads_enabled) {                         // If the plugin is not enabled, skip
 		return false;
 	}
 

--- a/tests/test-s3-uploads.php
+++ b/tests/test-s3-uploads.php
@@ -49,10 +49,18 @@ class Test_S3_Uploads extends WP_UnitTestCase {
 
 		$this->assertTrue( s3_uploads_enabled() );
 
-		update_option( 's3_uploads_enabled', 'enabled' );
+		if ( is_multisite() ) {
+			update_site_option( 's3_uploads_enabled', 'enabled' );
+		} else {
+			update_option( 's3_uploads_enabled', 'enabled' );
+		}
 		$this->assertTrue( s3_uploads_enabled() );
 
-		delete_option( 's3_uploads_enabled' );
+		if ( is_multisite() ) {
+			delete_site_option( 's3_uploads_enabled' );
+		} else {
+			delete_option( 's3_uploads_enabled' );
+		}
 		define( 'S3_UPLOADS_AUTOENABLE', false );
 
 		$this->assertFalse( s3_uploads_enabled() );


### PR DESCRIPTION
Made the plugin use site options if mutlisite is activated.
Now rewrites all the urls.

Also removed the Aws\S3\Sync\UploadSyncBuilder extend because it does not seem to be compatible with current AWS SDK included.
This might break the sync option when you run upload-directory in --sync mode but at least it works with the default upload-directory.