### PR TITLE
fix upload ContentType guess based on the key object file extension

### DIFF
--- a/inc/class-s3-uploads-stream-wrapper.php
+++ b/inc/class-s3-uploads-stream-wrapper.php
@@ -188,15 +188,15 @@ class S3_Uploads_Stream_Wrapper
 		$params['Body'] = $this->body;
 
 		//Added by EveryUP Srl
-		$objectKey = $params['Key'];
-		if(pathinfo($objectKey, PATHINFO_EXTENSION) == 'tmp') {
-			$objectKey = substr($objectKey, 0, -4);
+		$object_key = $params['Key'];
+		if ( pathinfo($object_key, PATHINFO_EXTENSION) === 'tmp' ) {
+			$object_key = substr($object_key, 0, -4);
 		}
 
 		// Attempt to guess the ContentType of the upload based on the
 		// file extension of the key. Added by Joe Hoyle
 		if (!isset($params['ContentType']) &&
-			($type = Psr7\mimetype_from_filename($objectKey))
+			($type = Psr7\mimetype_from_filename($object_key))
 		) {
 			$params['ContentType'] = $type;
 		}

--- a/inc/class-s3-uploads-stream-wrapper.php
+++ b/inc/class-s3-uploads-stream-wrapper.php
@@ -187,10 +187,16 @@ class S3_Uploads_Stream_Wrapper
 		$params = $this->getOptions(true);
 		$params['Body'] = $this->body;
 
+		//Added by EveryUP Srl
+		$objectKey = $params['Key'];
+		if(pathinfo($objectKey, PATHINFO_EXTENSION) == 'tmp') {
+			$objectKey = substr($objectKey, 0, -4);
+		}
+
 		// Attempt to guess the ContentType of the upload based on the
 		// file extension of the key. Added by Joe Hoyle
 		if (!isset($params['ContentType']) &&
-			($type = Psr7\mimetype_from_filename($params['Key']))
+			($type = Psr7\mimetype_from_filename($objectKey))
 		) {
 			$params['ContentType'] = $type;
 		}


### PR DESCRIPTION
wordpress append the .tmp extension to filenames when generating thumbnails. E.g.
<file-name>-150x150.jpg.tmp
So when guessing the ContentType from the extension the Psr7\mimetype_from_filename() will not work properly.
To avoid this issue, we strip the .tmp extension if present.