### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Once you have `git clone`d the repo, or added it as a Git Submodule, add the fol
 define( 'S3_UPLOADS_BUCKET', 'my-bucket' );
 define( 'S3_UPLOADS_KEY', '' );
 define( 'S3_UPLOADS_SECRET', '' );
-define( 'S3_UPLOADS_REGION', '' ); // the s3 bucket region, required for Frankfurt, Beijing & Sydney.
+define( 'S3_UPLOADS_REGION', '' ); // the s3 bucket region (excluding the rest of the URL)
 ```
 Please refer to this region list http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region for the S3_UPLOADS_REGION values.
 


### PR DESCRIPTION
1. Removes the reference to required regions, as all regions seem to require this field now.
2. Where (1) was, clarified that you should only enter the region, not the entire URL presented in the linked AWS documentations.