### PR TITLE
Fix instances of wp_tempnam not being defined

### DIFF
--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -278,6 +278,9 @@ class S3_Uploads {
 	 * @return string
 	 */
 	public function copy_image_from_s3( $file ) {
+		if ( ! function_exists( 'wp_tempnam' ) ) {
+			require_once( ABSPATH . 'wp-admin/includes/file.php' );
+		}
 		$temp_filename = wp_tempnam( $file );
 		copy( $file, $temp_filename );
 		return $temp_filename;


### PR DESCRIPTION
`wp_tempnam` is only defined during admin requests. Checking for the functions existence and requiring `wp-admin/includes/file.php` before calling ensures its existence.