### PR TITLE
Constant to define custom hook priority for URL Rewriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,10 @@ S3 Uploads' URL rewriting feature can be disabled if the current website does no
 // disable URL rewriting alltogether
 define( 'S3_UPLOADS_DISABLE_REPLACE_UPLOAD_URL', true );
 ```
-
+Sometimes due to conflicts with other plugins, you may want to have the URL Rewrite functionality to be executed using a different hook priority. For that you can specify it by setting the constant `S3_UPLOADS_RENAME_FOLDER_PRIORITY` in your configurations file. The default priority value is 10.
+```
+define('S3_UPLOADS_RENAME_FOLDER_PRIORITY', 10);
+```
 S3 Object Permissions
 =======
 


### PR DESCRIPTION
Hi,
I noticed an incompatibility when using this plugin while developing for an existent project that already does some URL rewriting. I am pretty sure that this incompatibility was happening because the setup we have uses [bedrock](https://roots.io/bedrock/)

So I added:
- A new constant to define default WP hook priority
- A new constant setting `S3_UPLOADS_RENAME_FOLDER_PRIORITY ` that developers can use to define a custom URL Rewrite priority if needed.

I tested it locally and it works fine. In my case I had to bump the permission to 11, instead of 10.
Let me know if this can be added or if something else needs to be amended.

Thank you!
Vinicius