### PR TITLE
Fix ACL on files uploaded via upload-directory

### DIFF
--- a/inc/class-s3-uploads-wp-cli-command.php
+++ b/inc/class-s3-uploads-wp-cli-command.php
@@ -324,8 +324,8 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 				$prefix . $to,
 				array(
 					'debug'       => true,
-					'params'      => function(\AWS\Command $command) {
-						$command['ACL'] = 'public-read';
+					'before'      => function(\AWS\Command $command) {
+						$command['ACL'] = defined('S3_UPLOAD_OBJECT_ACL') ? S3_UPLOAD_OBJECT_ACL : 'public-read';
 					},
 					'builder'     => new S3_Uploads_UploadSyncBuilder( ! empty( $args_assoc['dry-run'] ) ),
 					'force'       => empty( $args_assoc['sync'] ),

--- a/inc/class-s3-uploads-wp-cli-command.php
+++ b/inc/class-s3-uploads-wp-cli-command.php
@@ -324,7 +324,9 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 				$prefix . $to,
 				array(
 					'debug'       => true,
-					'params'      => array( 'ACL' => 'public-read' ),
+					'params'      => function(\AWS\Command $command) {
+						$command['ACL'] = 'public-read';
+					},
 					'builder'     => new S3_Uploads_UploadSyncBuilder( ! empty( $args_assoc['dry-run'] ) ),
 					'force'       => empty( $args_assoc['sync'] ),
 					'concurrency' => ! empty( $args_assoc['concurrency'] ) ? $args_assoc['concurrency'] : 5,


### PR DESCRIPTION
This fixes ACL permission on files uploaded through `upload-directory` command. 

```
wp s3-uploads upload-directory wp-content/uploads s3://uploads
```

Files in the upload directory uploaded through command above are not accessible to the public despite the ACL `public-read` permission set by default.

Going by the fix to the issue [here](https://github.com/aws/aws-sdk-php/issues/867#issuecomment-169147302). I was able to set the right permissions for all the files in the directory. 