### PR TITLE
Request only attachment ids instead of full row data when migrating attachments

### DIFF
--- a/inc/class-s3-uploads-wp-cli-command.php
+++ b/inc/class-s3-uploads-wp-cli-command.php
@@ -63,13 +63,14 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 			'post_type'      => 'attachment',
 			'posts_per_page' => -1,
 			'post_status'    => 'all',
+			'fields'	 => 'ids'
 		));
 
-		WP_CLI::line( sprintf( 'Attempting to move %d attachments to S3', $attachments->found_posts ) );
+		WP_CLI::line( sprintf( 'Attempting to move %d attachments to S3', count($attachments->posts) ) );
 
-		foreach ( $attachments->posts as $attachment ) {
+		foreach ( $attachments->posts as $attachmentID ) {
 
-			$this->migrate_attachment_to_s3( array( $attachment->ID ), $args_assoc );
+			$this->migrate_attachment_to_s3( array( $attachmentID ), $args_assoc );
 		}
 
 		WP_CLI::success( 'Moved all attachments to S3. If you wish to update references in your database run: ' );


### PR DESCRIPTION
Have used the plugin to migrate ~ 300k images and 1.5M image files. The plugin requests all image data and uses only the IDs in `function migrate_attachments_to_s3() in class-s3-uploads-wp-cli-command.php file`.

This resulted in Out of memory errors with 1.5GB memory allocated. 

Editing the function to request only ids from the database improves the performance and prevents memory exhaustion. 