### PR TITLE
feat: Add support for S3-compatible Object Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,20 @@ S3 Uploads' URL rewriting feature can be disabled if the current website does no
 define( 'S3_UPLOADS_DISABLE_REPLACE_UPLOAD_URL', true );
 ```
 
+Changing URL for Uploads
+=======
+
+By default, your files will be uploaded to the URL `https://[bucket name].s3.amazonaws.com`.
+You can change this behavior by defining `S3_UPLOADS_BUCKET_ENDPOINT_URL` in your `wp-settings.php`:
+
+```PHP
+// e.g. for Scaleway
+define( 'S3_UPLOADS_BUCKET_ENDPOINT_URL', 'https://s3.nl-ams.scw.cloud' );
+```
+
+When defining this constant, it will automatically configure the URL rewriting (unless it has been configured manually) for your uploads.
+Given the previous example, your uploads will be loaded from `https://[bucket name].s3.nl-ams.scw.cloud`.
+
 S3 Object Permissions
 =======
 

--- a/tests/test-s3-uploads.php
+++ b/tests/test-s3-uploads.php
@@ -171,4 +171,23 @@ class Test_S3_Uploads extends WP_UnitTestCase {
 		$this->assertEquals( 'hmn-uploads', $uploads->get_s3_bucket() );
 	}
 
+	function test_s3_custom_endpoint() {
+	    $uploads = new S3_Uploads('my-bucket', S3_UPLOADS_KEY, S3_UPLOADS_SECRET, null, S3_UPLOADS_REGION, 'https://s3.nl-ams.scw.cloud');
+
+        $endpoint = $uploads->s3()->getEndpoint();
+	    $this->assertEquals('https', $endpoint->getScheme());
+	    $this->assertEquals('s3.nl-ams.scw.cloud', $endpoint->getHost());
+
+	    $this->assertEquals('https://my-bucket.s3.nl-ams.scw.cloud', $uploads->get_s3_url());
+    }
+
+	function test_s3_custom_endpoint_with_defined_bucket_url() {
+	    $uploads = new S3_Uploads('my-bucket', S3_UPLOADS_KEY, S3_UPLOADS_SECRET, 'https://my-url.com', S3_UPLOADS_REGION, 'https://s3.nl-ams.scw.cloud');
+
+        $endpoint = $uploads->s3()->getEndpoint();
+	    $this->assertEquals('https', $endpoint->getScheme());
+	    $this->assertEquals('s3.nl-ams.scw.cloud', $endpoint->getHost());
+
+	    $this->assertEquals('https://my-url.com', $uploads->get_s3_url());
+    }
 }


### PR DESCRIPTION
Hi,

This feature add the support for S3-compatible Object Storage (like [Scaleway](https://www.scaleway.com/object-storage/) which is cheaper).

Actually we can configure the URL rewriting when displaying files (when using a CDN), but we can't configure the S3 endpoint (that is used for uploads, removal, ...) because the endpoint `[bucket name].s3.amazonaws.com` is hardcoded. 

With this feature, we can configure where our files will be uploaded like this:

```php
define('S3_UPLOADS_BUCKET_ENDPOINT_URL', 'https://s3.nl-ams.scw.cloud');
```

Also, it will automatically configure the URL rewriting (if it has not been configured manually). 
In this case, `$uploads->get_s3_url()` will returns `https://[bucket name].s3.nl-ams.scw.cloud`.

I added some tests but I was not able to ran them locally. 

This is the behavior on a real-project (already in production with our fork):

![bibliotheque de medias bwt wordpress - google chrome_176](https://user-images.githubusercontent.com/2103975/52649535-c7bf3c80-2ee8-11e9-99ba-c97ff98255a0.png)
The file have the good URL

![selection_177](https://user-images.githubusercontent.com/2103975/52649537-c9890000-2ee8-11e9-872a-db89b252944d.png)
The file is properly uploaded to Scaleway's Object Storage.

Thanks to consider this PR :slightly_smiling_face: 