### PR TITLE
Don't include tests in the downloadable composer package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/tests export-ignore
+/bin export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
It's possible to remove the `tests` (and some other files) from the git archive that composer downloads from github on install. This saves a few MB as we have test images / pdfs and videos in our tests directory