### PR TITLE
Don't add resource hints if no external S3 URL is used

### DIFF
--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -256,6 +256,13 @@ class S3_Uploads {
 	 * @return array
 	 */
 	function wp_filter_resource_hints( $hints, $relation_type ) {
+		if (
+			( defined( 'S3_UPLOADS_DISABLE_REPLACE_UPLOAD_URL' ) && S3_UPLOADS_DISABLE_REPLACE_UPLOAD_URL ) ||
+			( defined( 'S3_UPLOADS_USE_LOCAL' ) && S3_UPLOADS_USE_LOCAL )
+		) {
+			return $hints;
+		}
+
 		if ( 'dns-prefetch' === $relation_type ) {
 			$hints[] = $this->get_s3_url();
 		}


### PR DESCRIPTION
If `S3_UPLOADS_DISABLE_REPLACE_UPLOAD_URL` or `S3_UPLOADS_USE_LOCAL` is set, the prefetch resource hint shouldn't be registered to prevent an unused look up.