### PR TITLE
PHP Version Check is causing issues - fix for issue #343

### DIFF
--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -85,7 +85,7 @@ function s3_uploads_check_requirements() {
  * This has to be a named function for compatibility with PHP 5.2.
  */
 function s3_uploads_outdated_php_version_notice() {
-	printf( '<div class="error"><p>The S3 Uploads plugin requires PHP version 5.5.0 or higher. Your server is running PHP version %s.</p></div>',
+	printf( '<div class="notice notice-error"><p>The S3 Uploads plugin requires PHP version 5.5.0 or higher. Your server is running PHP version %s.</p></div>',
 		PHP_VERSION
 	);
 }

--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -71,12 +71,12 @@ function s3_uploads_check_requirements() {
 	if ( version_compare( '5.5.0', PHP_VERSION, '>' ) ) {
 		if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
 			add_action( 'admin_notices', 's3_uploads_outdated_php_version_notice' );
+			return false;
 		}
 
-		return false;
+		return true;
 	}
 
-	return true;
 }
 
 /**


### PR DESCRIPTION
The s3_uploads_check_requirements function now passes properly if PHP_VERSION is above 5.5.0
The Admin message if the PHP version is below 5.5.0 is classed according to the WP Codex (https://codex.wordpress.org/Plugin_API/Action_Reference/admin_notices)