### PR TITLE
Using wp_delete_file() instead of unlink()

### DIFF
--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -122,11 +122,11 @@ class S3_Uploads {
 		if ( ! empty( $meta['sizes'] ) ) {
 			foreach ( $meta['sizes'] as $sizeinfo ) {
 				$intermediate_file = str_replace( basename( $file ), $sizeinfo['file'], $file );
-				unlink( $intermediate_file );
+				wp_delete_file( $intermediate_file );
 			}
 		}
 
-		unlink( $file );
+		wp_delete_file( $file );
 	}
 
 	public function get_s3_url() {


### PR DESCRIPTION
The use of unlink() breaks functionality of some third-party WordPress plugins.
The use of wp_delete_file() is preferred over unlink() since it allows filtering the file before deletion
Please consider including this in your codebase.