### PR TITLE
Remove upload-directory --sync and --dry-run cli options from documentation as they were removed in fef7efb

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,6 @@ If you have an existing media library with attachment files, use the below comma
 wp s3-uploads upload-directory <from> <to> [--verbose]
 ```
 
-Passing `--sync` will only upload files that are newer in `<from>` or that don't exist on S3 already. Use `--dry-run` to test.
-
 For example, to migrate your whole uploads directory to S3, you'd run:
 
 ```


### PR DESCRIPTION
It seems like the `--sync` and `--dry-run` cli options were removed in fef7efb but were not removed from documentation which caused some confusion and I opened issue #327. This pull request simply removes them from README.md.