### PR TITLE
Fix verify WP CLI command

### DIFF
--- a/inc/class-s3-uploads-wp-cli-command.php
+++ b/inc/class-s3-uploads-wp-cli-command.php
@@ -20,13 +20,13 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 
 		// Create a path in the base directory, with a random file name to avoid potentially overwriting existing data.
 		$upload_dir = wp_upload_dir();
-		$s3_path    = $upload_dir['basedir'] . '/' . mt_rand() . '.jpg';
+		$s3_path    = $upload_dir['basedir'] . '/' . mt_rand() . '.txt';
 
 		// Attempt to copy the local Canola test file to the generated path on S3.
 		WP_CLI::print_value( 'Attempting to upload file ' . $s3_path );
 
 		$copy = copy(
-			dirname( dirname( __FILE__ ) ) . '/tests/data/sunflower.jpg',
+			dirname( dirname( __FILE__ ) ) . '/verify.txt',
 			$s3_path
 		);
 

--- a/verify.txt
+++ b/verify.txt
@@ -1,0 +1,1 @@
+Beep boop

--- a/verify.txt
+++ b/verify.txt
@@ -1,1 +1,1 @@
-Beep boop
+• Todo: migrate to Altis


### PR DESCRIPTION
`tests/` isn't included in the release package, so this instead uses a small text file to use for verification instead.