### PR TITLE
Add support for Private Attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ Private uploads can be transitioned to public by calling `S3_Uploads::set_attach
 S3_Uploads::get_instance()->set_attachment_files_acl( 15, 'public-read' );
 ```
 
+The default expiry for all private file URLs is 24 hours. You can modify this by using the `s3_uploads_private_attachment_url_expiry` WordPress filter. The value can be any string interpreted by `strtotime`. For example:
+
+```php
+add_filter( 's3_uploads_private_attachment_url_expiry', function ( $expiry ) {
+	return '+1 hour';
+} );
+```
+
 ## Cache Control
 
 You can define the default HTTP `Cache-Control` header for uploaded media using the

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Note: as either `<from>` or `<to>` can be S3 or local locations, you must specif
 
 WordPress (and therefor S3 Uploads) default behaviour is that all uploaded media files are publicly accessible. In certain cases which may not be desireable. S3 Uploads supports setting S3 Objects to a `private` ACL and providing temporarily signed URLs for all files that are marked as private.
 
-S3 Uploads does not make assumptions for provide UI for marking attachments as private, instead you should integrate the `s3_uploads_is_attachment_private` WordPress filter to control the behaviour. For example, to mark _all_ attachments as private:
+S3 Uploads does not make assumptions or provide UI for marking attachments as private, instead you should integrate the `s3_uploads_is_attachment_private` WordPress filter to control the behaviour. For example, to mark _all_ attachments as private:
 
 ```php
 add_filter( 's3_uploads_is_attachment_private', '__return_true' );

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ It's focused on providing a highly robust S3 interface with no "bells and whistl
 
 ## Requirements
 
-- PHP >= 5.5
+- PHP >= 7.1
 - WordPress >= 5.3
 
 ## Getting Set Up
@@ -129,6 +129,22 @@ wp s3-uploads cp <from> <to>
 ```
 
 Note: as either `<from>` or `<to>` can be S3 or local locations, you must specify the full S3 location via `s3://mybucket/mydirectory` for example `cp ./test.txt s3://mybucket/test.txt`.
+
+## Private Uploads
+
+WordPress (and therefor S3 Uploads) default behaviour is that all uploaded media files are publicly accessible. In certain cases which may not be desireable. S3 Uploads supports setting S3 Objects to a `private` ACL and providing temporarily signed URLs for all files that are marked as private.
+
+S3 Uploads does not make assumptions for provide UI for marking attachments as private, instead you should integrate the `s3_uploads_is_attachment_private` WordPress filter to control the behaviour. For example, to mark _all_ attachments as private:
+
+```php
+add_filter( 's3_uploads_is_attachment_private', '__return_true' );
+```
+
+Private uploads can be transitioned to public by calling `S3_Uploads::set_attachment_files_acl( $id, 'public-read' )` or vica-versa. For example:
+
+```php
+S3_Uploads::get_instance()->set_attachment_files_acl( 15, 'public-read' );
+```
 
 ## Cache Control
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Private uploads can be transitioned to public by calling `S3_Uploads::set_attach
 S3_Uploads::get_instance()->set_attachment_files_acl( 15, 'public-read' );
 ```
 
-The default expiry for all private file URLs is 24 hours. You can modify this by using the `s3_uploads_private_attachment_url_expiry` WordPress filter. The value can be any string interpreted by `strtotime`. For example:
+The default expiry for all private file URLs is 6 hours. You can modify this by using the `s3_uploads_private_attachment_url_expiry` WordPress filter. The value can be any string interpreted by `strtotime`. For example:
 
 ```php
 add_filter( 's3_uploads_private_attachment_url_expiry', function ( $expiry ) {

--- a/inc/class-s3-uploads-wp-cli-command.php
+++ b/inc/class-s3-uploads-wp-cli-command.php
@@ -308,6 +308,31 @@ class S3_Uploads_WP_CLI_Command extends WP_CLI_Command {
 		WP_CLI::success( 'Media URL rewriting disabled.' );
 	}
 
+	/**
+	 * List all files for a given attachment.
+	 *
+	 * Useful for debugging.
+	 *
+	 * @subcommand get-attachment-files
+	 * @synopsis <attachment-id>
+	 */
+	public function get_attachment_files( $args ) {
+		WP_CLI::print_value( S3_Uploads::get_attachment_files( $args[0] ) );
+	}
+
+	/**
+	 * Update the ACL of all files for an attachment.
+	 *
+	 * Useful for debugging.
+	 *
+	 * @subcommand set-attachment-acl
+	 * @synopsis <attachment-id> <acl>
+	 */
+	public function set_attachment_acl( $args ) {
+		$result = S3_Uploads::get_instance()->set_attachment_files_acl( $args[0], $args[1] );
+		WP_CLI::print_value( $result );
+	}
+
 	private function recurse_copy( $src, $dst ) {
 		$dir = opendir( $src );
 		@mkdir( $dst );

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -446,7 +446,7 @@ class S3_Uploads {
 			'Key' => $path['key'],
 		]);
 
-		$presigned_url_expires = apply_filters( 's3_uploads_private_attachment_url_expiry', '+24 hours' );
+		$presigned_url_expires = apply_filters( 's3_uploads_private_attachment_url_expiry', '+24 hours', $post_id );
 		$query = $this->s3()->createPresignedRequest( $cmd, $presigned_url_expires )->getUri()->getQuery();
 
 		// The URL could have query params on it already (such as being an already signed URL),

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -30,7 +30,7 @@ class S3_Uploads {
 		return self::$instance;
 	}
 
-	public function __construct( string $bucket, string $key, string $secret, string $bucket_url = null, string $region = null ) {
+	public function __construct( $bucket, $key, $secret, $bucket_url = null, $region = null ) {
 
 		$this->bucket     = $bucket;
 		$this->key        = $key;

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -446,7 +446,8 @@ class S3_Uploads {
 			'Key' => $path['key'],
 		]);
 
-		$query = $this->s3()->createPresignedRequest( $cmd, '+24 hours' )->getUri()->getQuery();
+		$presigned_url_expires = apply_filters( 's3_uploads_private_attachment_url_expiry', '+24 hours' );
+		$query = $this->s3()->createPresignedRequest( $cmd, $presigned_url_expires )->getUri()->getQuery();
 
 		// The URL could have query params on it already (such as being an already signed URL),
 		// but query params will mean the S3 signed URL will become corrupt. So, we have to

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -456,7 +456,7 @@ class S3_Uploads {
 			'Key' => $path['key'],
 		]);
 
-		$presigned_url_expires = apply_filters( 's3_uploads_private_attachment_url_expiry', '+24 hours', $post_id );
+		$presigned_url_expires = apply_filters( 's3_uploads_private_attachment_url_expiry', '+6 hours', $post_id );
 		$query = $this->s3()->createPresignedRequest( $cmd, $presigned_url_expires )->getUri()->getQuery();
 
 		// The URL could have query params on it already (such as being an already signed URL),

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -387,11 +387,12 @@ class S3_Uploads {
 				'Key' => $location['key'],
 				'ACL' => $acl,
 			] );
-			try {
-				Aws\CommandPool::batch( $s3, $commands );
-			} catch ( Exception $e ) {
-				return new WP_Error( $e->getCode(), $e->getMessage() );
-			}
+		}
+
+		try {
+			Aws\CommandPool::batch( $s3, $commands );
+		} catch ( Exception $e ) {
+			return new WP_Error( $e->getCode(), $e->getMessage() );
 		}
 
 		return null;

--- a/inc/class-s3-uploads.php
+++ b/inc/class-s3-uploads.php
@@ -472,11 +472,15 @@ class S3_Uploads {
 	/**
 	 * Add the S3 signed params to an image src array.
 	 *
-	 * @param array $image
+	 * @param array|false $image
 	 * @param integer $post_id
-	 * @return array
+	 * @return array|false
 	 */
-	public function add_s3_signed_params_to_attachment_image_src( array $image, int $post_id ) : array {
+	public function add_s3_signed_params_to_attachment_image_src( $image, int $post_id ) {
+		if ( ! $image ) {
+			return $image;
+		}
+
 		$image[0] = $this->add_s3_signed_params_to_attachment_url( $image[0], $post_id );
 		return $image;
 	}

--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -61,7 +61,7 @@ function s3_uploads_init() {
 function s3_uploads_check_requirements() {
 	global $wp_version;
 
-	if ( version_compare( PHP_VERSION, '5.5.0', '<' ) ) {
+	if ( version_compare( PHP_VERSION, '7.1', '<' ) ) {
 		if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
 			add_action( 'admin_notices', 's3_uploads_outdated_php_version_notice' );
 		}


### PR DESCRIPTION
This is an experiment to support private / unpublished uploads. These files are pushed to S3 with a private ACL, and then URLs are generated and signed when pages are generated, with a time-based expiry.