### PR TITLE
Catch S3 Delete Error

### DIFF
--- a/inc/class-s3-uploads-stream-wrapper.php
+++ b/inc/class-s3-uploads-stream-wrapper.php
@@ -638,11 +638,15 @@ class S3_Uploads_Stream_Wrapper
 				isset($options['acl']) ? $options['acl'] : 'private',
 				$options
 			);
-			// Delete the original object
-			$this->getClient()->deleteObject([
-				'Bucket' => $partsFrom['Bucket'],
-				'Key'    => $partsFrom['Key']
-			] + $options);
+			try {
+				// Delete the original object
+				$this->getClient()->deleteObject([
+					'Bucket' => $partsFrom['Bucket'],
+					'Key'    => $partsFrom['Key']
+				] + $options);
+			} catch (Exception $e) {
+
+			}
 			return true;
 		});
 	}


### PR DESCRIPTION
**Context** We have a requirement to restrict the S3 bucket and prevent delete operations to ensure any malicious or accidental changes don't impact the production website.

**Problem** When GravityForms uploads PDF attachments it puts them in a tmp folder and then moves them to the final location. This coupled with the delete restriction causes an error which stops GravityForms form correctly linking the location of the uploaded PDF.

The solution is quite simple, just a try catch around the delete operation. However, I'm not sure how to raise a warning so any help with completing this would be greatly appreciated.