### PR TITLE
Fix issue preventing local stream wrapper from working with symlinked upload directories

### DIFF
--- a/inc/class-s3-uploads-local-stream-wrapper.php
+++ b/inc/class-s3-uploads-local-stream-wrapper.php
@@ -127,7 +127,7 @@ class S3_Uploads_Local_Stream_Wrapper {
 		if ( ! isset( $uri ) ) {
 			$uri = $this->uri;
 		}
-		$path = $this->getDirectoryPath() . '/' . $this->getTarget( $uri );
+		$path = realpath( $this->getDirectoryPath() ) . '/' . $this->getTarget( $uri );
 		$realpath = $path;
 
 		$directory = realpath( $this->getDirectoryPath() );


### PR DESCRIPTION
It's a pretty common pattern to have the uploads folder in WordPress symlinked to a separate directory when deployed. However the local stream wrapper doesn't work when this is the case, because of this code here:

https://github.com/humanmade/S3-Uploads/blob/577886b941438793a5721bbbb6eddc6872ee73cb/inc/class-s3-uploads-local-stream-wrapper.php#L130-L137

This compares the nominal uploads directory with the realpath of that directory, which resolves the symlink and so is a different path. This causes the `strpos( $realpath, $directory ) !== 0` to always evaluate to true which makes the getLocalPath function always return false.

It seems like the best solution would be to also realpath the generated filename so they both have the resolved symlink path:
```diff
- $path = $this->getDirectoryPath() . '/' . $this->getTarget( $uri );
+ $path = realpath( $this->getDirectoryPath() ) . '/' . $this->getTarget( $uri );
```