### PR TITLE
Save filesize with attachment metadata on upload

### DIFF
--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -409,9 +409,9 @@ class Plugin {
 	 * Saving the filesize in the attachment metadata when the image is
 	 * uploaded allows core to skip this stat when retrieving and formatting it.
 	 *
-	 * @param array $metadata      Attachment metadata.
+	 * @param array{width: int, height: int, file?: string, sizes: array, image_meta: array} $metadata      Attachment metadata.
 	 * @param int   $attachment_id Attachment ID.
-	 * @return array Attachment metadata array, with "filesize" value added.
+	 * @return array{width: int, height: int, file?: string, sizes: array, image_meta: array, filesize: int} Attachment metadata array, with "filesize" value added.
 	 */
 	function set_filesize_in_attachment_meta( array $metadata, int $attachment_id  ) : array {
 		$file = get_attached_file( $attachment_id );

--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -411,7 +411,7 @@ class Plugin {
 	 *
 	 * @param array{file?: string} $metadata      Attachment metadata.
 	 * @param int                  $attachment_id Attachment ID.
-	 * @return array{file?: string, filesize: int} Attachment metadata array, with "filesize" value added.
+	 * @return array{file?: string, filesize?: int} Attachment metadata array, with "filesize" value added.
 	 */
 	function set_filesize_in_attachment_meta( array $metadata, int $attachment_id ) : array {
 		$file = get_attached_file( $attachment_id );

--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -412,7 +412,7 @@ class Plugin {
 	 * @param array $metadata Attachment metadata.
 	 * @return array Attachment metadata array, with "filesize" value added.
 	 */
-	function set_filesize_in_attachment_meta( $metadata ) {
+	function set_filesize_in_attachment_meta( array $metadata ) : array {
 		$uploads_dir = wp_upload_dir();
 
 		$file = path_join( $uploads_dir['basedir'], $metadata['file'] );

--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -110,7 +110,7 @@ class Plugin {
 		add_filter( 'wp_resource_hints', [ $this, 'wp_filter_resource_hints' ], 10, 2 );
 
 		add_action( 'wp_handle_sideload_prefilter', [ $this, 'filter_sideload_move_temp_file_to_s3' ] );
-		add_filter( 'wp_generate_attachment_metadata', [ $this, 'set_filesize_in_attachment_meta' ] );
+		add_filter( 'wp_generate_attachment_metadata', [ $this, 'set_filesize_in_attachment_meta' ], 10, 2 );
 
 		add_action( 'wp_get_attachment_url', [ $this, 'add_s3_signed_params_to_attachment_url' ], 10, 2 );
 		add_action( 'wp_get_attachment_image_src', [ $this, 'add_s3_signed_params_to_attachment_image_src' ], 10, 2 );
@@ -409,13 +409,12 @@ class Plugin {
 	 * Saving the filesize in the attachment metadata when the image is
 	 * uploaded allows core to skip this stat when retrieving and formatting it.
 	 *
-	 * @param array $metadata Attachment metadata.
+	 * @param array $metadata      Attachment metadata.
+	 * @param int   $attachment_id Attachment ID.
 	 * @return array Attachment metadata array, with "filesize" value added.
 	 */
-	function set_filesize_in_attachment_meta( array $metadata ) : array {
-		$uploads_dir = wp_upload_dir();
-
-		$file = path_join( $uploads_dir['basedir'], $metadata['file'] );
+	function set_filesize_in_attachment_meta( array $metadata, int $attachment_id  ) : array {
+		$file = get_attached_file( $attachment_id );
 
 		if ( file_exists( $file ) ) {
 			$metadata['filesize'] = filesize( $file );

--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -409,9 +409,9 @@ class Plugin {
 	 * Saving the filesize in the attachment metadata when the image is
 	 * uploaded allows core to skip this stat when retrieving and formatting it.
 	 *
-	 * @param array{width: int, height: int, file?: string, sizes: array, image_meta: array} $metadata      Attachment metadata.
-	 * @param int   $attachment_id Attachment ID.
-	 * @return array{width: int, height: int, file?: string, sizes: array, image_meta: array, filesize: int} Attachment metadata array, with "filesize" value added.
+	 * @param array{file?: string} $metadata      Attachment metadata.
+	 * @param int                  $attachment_id Attachment ID.
+	 * @return array{file?: string, filesize: int} Attachment metadata array, with "filesize" value added.
 	 */
 	function set_filesize_in_attachment_meta( array $metadata, int $attachment_id ) : array {
 		$file = get_attached_file( $attachment_id );

--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -415,7 +415,9 @@ class Plugin {
 	 */
 	function set_filesize_in_attachment_meta( array $metadata, int $attachment_id ) : array {
 		$file = get_attached_file( $attachment_id );
-
+		if ( ! $file ) {
+			return $metadata;
+		}
 		if ( ! isset( $metadata['filesize'] ) && file_exists( $file ) ) {
 			$metadata['filesize'] = filesize( $file );
 		}

--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -413,7 +413,7 @@ class Plugin {
 	 * @param int   $attachment_id Attachment ID.
 	 * @return array{width: int, height: int, file?: string, sizes: array, image_meta: array, filesize: int} Attachment metadata array, with "filesize" value added.
 	 */
-	function set_filesize_in_attachment_meta( array $metadata, int $attachment_id  ) : array {
+	function set_filesize_in_attachment_meta( array $metadata, int $attachment_id ) : array {
 		$file = get_attached_file( $attachment_id );
 
 		if ( file_exists( $file ) ) {

--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -416,7 +416,7 @@ class Plugin {
 	function set_filesize_in_attachment_meta( array $metadata, int $attachment_id ) : array {
 		$file = get_attached_file( $attachment_id );
 
-		if ( file_exists( $file ) ) {
+		if ( ! isset( $metadata['filesize'] ) && file_exists( $file ) ) {
 			$metadata['filesize'] = filesize( $file );
 		}
 


### PR DESCRIPTION
Sets the "filesize" property in the attachment metadata when initially uploading images, so that it doesn't have to be queried for in the ajax response on `wp_prepare_attachment_for_js()`.

Fixes #492.