### PR TITLE
Don't install dev deps in manual install

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,11 +16,11 @@ jobs:
     - uses: "shivammathur/setup-php@v2"
       with:
         php-version: "7.4"
+        extensions: pcov
     - name: Install dependencies
       uses: ramsey/composer-install@v1
       with:
         composer-options: '-oa --no-dev'
-        extensions: pcov
 
     - name: Archive assets
       uses: thedoctor0/zip-release@master

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -3,6 +3,8 @@ name: Build Release
 on:
   release:
     types: [ published ]
+  workflow_dispatch:
+
 
 jobs:
   build-manual-install:
@@ -15,7 +17,7 @@ jobs:
     - name: Install dependencies
       uses: nick-zh/composer@php7.3
       with:
-        args: 'install -oa'
+        args: 'install -oa --no-dev'
 
     - name: Archive assets
       uses: thedoctor0/zip-release@master

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,12 +13,13 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-
+    - uses: "shivammathur/setup-php@v2"
+      with:
+        php-version: "7.4"
     - name: Install dependencies
       uses: ramsey/composer-install@v1
       with:
         composer-options: '-oa --no-dev'
-        php-version: "7.4"
 
     - name: Archive assets
       uses: thedoctor0/zip-release@master

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,9 +15,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install dependencies
-      uses: nick-zh/composer@php7.3
+      uses: ramsey/composer-install@v1
       with:
-        args: 'install -oa --no-dev'
+        composer-options: '-oa --no-dev'
+        php-version: "7.4"
 
     - name: Archive assets
       uses: thedoctor0/zip-release@master

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,6 +20,7 @@ jobs:
       uses: ramsey/composer-install@v1
       with:
         composer-options: '-oa --no-dev'
+        extensions: pcov
 
     - name: Archive assets
       uses: thedoctor0/zip-release@master


### PR DESCRIPTION
I added `workflow_dispatch` too, to be able to debug with https://github.blog/2021-04-15-work-with-github-actions-in-your-terminal-with-github-cli/
