### PR TITLE
[BC break] Keep Guzzle v6 in v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 	"type": "wordpress-plugin",
 	"require": {
 		"composer/installers": "~1.0",
-		"aws/aws-sdk-php": "~3.18"
-	 }
+		"aws/aws-sdk-php": "~3.18",
+		"guzzlehttp/guzzle": "^6.2"
+	}
 }


### PR DESCRIPTION
This plugin is bundled with `aws-sdk-php` which requires `guzzlehttp/guzzle:^5.3.3|^6.2.1|^7.0`.
In version 2.2.1 there was `guzzlehttp/guzzle:6.5.5`.
But in 2.3.0  it's now `guzzlehttp/guzzle:7.2.0`.

I have other plugins that require guzzle v6 and they crashed after the update to v2.3.0.
Since in PHP it's not possible to have 2 classes loaded of a different version, because if the class is already loaded it will not load it twice.

Please downgrade the guzzle version, at least in v2.
