### PR TITLE
fix: always require autoload.php

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -2,13 +2,9 @@
 
 namespace S3_Uploads;
 
-function init() {
-	// Ensure the AWS SDK can be loaded.
-	if ( ! class_exists( '\\Aws\\S3\\S3Client' ) ) {
-		// Require AWS Autoloader file.
-		require_once dirname( __DIR__ ) . '/vendor/autoload.php';
-	}
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 
+function init() {
 	if ( ! check_requirements() ) {
 		return;
 	}


### PR DESCRIPTION
This fixes https://github.com/humanmade/S3-Uploads/issues/515, a fatal missing class error on the site as well as in WP CLI commands with the plugin active and the AWS SDK loaded from another source.