### PR TITLE
Fix for issue #532 - fix local-stream-wrapper

### DIFF
--- a/inc/class-local-stream-wrapper.php
+++ b/inc/class-local-stream-wrapper.php
@@ -512,7 +512,7 @@ class Local_Stream_Wrapper {
 	 */
 	public function dir_opendir( $uri, $options ) {
 		$this->uri = $uri;
-		$this->handle = opendir( pathinfo($this->getLocalPath(), PATHINFO_DIRNAME) );
+		$this->handle = opendir( pathinfo( $this->getLocalPath(), PATHINFO_DIRNAME ) );
 
 		return (bool) $this->handle;
 	}

--- a/inc/class-local-stream-wrapper.php
+++ b/inc/class-local-stream-wrapper.php
@@ -14,7 +14,7 @@ namespace S3_Uploads;
  *
  * This is for the most part taken from Drupal, with some modifications.
  */
-class Local_Stream_Wrapper{
+class Local_Stream_Wrapper {
 	/**
 	 * Stream context resource.
 	 *

--- a/inc/class-local-stream-wrapper.php
+++ b/inc/class-local-stream-wrapper.php
@@ -14,7 +14,7 @@ namespace S3_Uploads;
  *
  * This is for the most part taken from Drupal, with some modifications.
  */
-class Local_Stream_Wrapper {
+class Local_Stream_Wrapper{
 	/**
 	 * Stream context resource.
 	 *
@@ -512,7 +512,7 @@ class Local_Stream_Wrapper {
 	 */
 	public function dir_opendir( $uri, $options ) {
 		$this->uri = $uri;
-		$this->handle = opendir( $this->getLocalPath() );
+		$this->handle = opendir( pathinfo($this->getLocalPath(), PATHINFO_DIRNAME) );
 
 		return (bool) $this->handle;
 	}

--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -5,6 +5,7 @@ namespace S3_Uploads;
 use Aws;
 use Exception;
 use WP_Error;
+use S3_Uploads\Local_Stream_Wrapper;
 
 /**
  * @psalm-consistent-constructor
@@ -144,7 +145,7 @@ class Plugin {
 	 */
 	public function register_stream_wrapper() {
 		if ( defined( 'S3_UPLOADS_USE_LOCAL' ) && S3_UPLOADS_USE_LOCAL ) {
-			stream_wrapper_register( 's3', 'S3_Uploads_Local_Stream_Wrapper', STREAM_IS_URL );
+			stream_wrapper_register( 's3', Local_Stream_Wrapper::class, STREAM_IS_URL );
 		} else {
 			Stream_Wrapper::register( $this );
 			$acl = defined( 'S3_UPLOADS_OBJECT_ACL' ) ? S3_UPLOADS_OBJECT_ACL : 'public-read';

--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -5,7 +5,6 @@ namespace S3_Uploads;
 use Aws;
 use Exception;
 use WP_Error;
-use S3_Uploads\Local_Stream_Wrapper;
 
 /**
  * @psalm-consistent-constructor


### PR DESCRIPTION
Hi,

This is the fix for Issue #532.

The registration of the local stream wrapper is changed to use the new namespaces.
The local stream wrapper better handles the wildcard for duplicate-search.