### PR TITLE
Load S3 Uploads at 0 priority, rather than 10

### DIFF
--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -10,7 +10,7 @@ Author URI: https://hmn.md
 
 require_once __DIR__ . '/inc/namespace.php';
 
-add_action( 'plugins_loaded', 'S3_Uploads\\init' );
+add_action( 'plugins_loaded', 'S3_Uploads\\init', 0 );
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	WP_CLI::add_command( 's3-uploads', 'S3_Uploads\\WP_CLI_Command' );


### PR DESCRIPTION
This allows other plugins on the default priority to load correctly.

Fixes #540.