### PR TITLE
Remove misleading documentation from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,7 @@ like so:
 wp s3-uploads verify
 ```
 
-You'll want to create a new IAM user for the S3-Uploads plugin, so you are not using admin level access keys on your site. S3-Uploads can create the IAM user for you and asign the correct permissions.
-
-```
-wp s3-uploads create-iam-user --admin-key=<key> --admin-secret=<secret>
-```
-
-This will provide you with a new Access Key and Secret Key which you can configure S3-Uploads with. Paste the values in the `wp-config.php`. Once you have migrated your media to S3 with any of the below methods, you'll want to enable S3 Uploads: `wp s3-uploads enable`.
-
-If you want to create your IAM user yourself, or attach the necessary permissions to an existing user, you can output the policy via `wp s3-uploads generate-iam-policy`
+You will need to create your IAM user yourself, or attach the necessary permissions to an existing user, you can output the policy via `wp s3-uploads generate-iam-policy`
 
 
 ## Listing files on S3


### PR DESCRIPTION
Documentation in README.md suggests you can create an IAM user using the `create-iam-user ` subcommand, however this subcommand does not actually exist.