### PR TITLE
Image Editor Imagick: Always return the WP_Error object of parent call

### DIFF
--- a/inc/class-image-editor-imagick.php
+++ b/inc/class-image-editor-imagick.php
@@ -106,8 +106,11 @@ class Image_Editor_Imagick extends WP_Image_Editor_Imagick {
 		 */
 		$parent_call = parent::_save( $image, $temp_filename ?: $filename, $mime_type );
 
-		if ( is_wp_error( $parent_call ) && $temp_filename ) {
-			unlink( $temp_filename );
+		if ( is_wp_error( $parent_call ) ) {
+			if ( $temp_filename ) {
+				unlink( $temp_filename );
+			}
+
 			return $parent_call;
 		} else {
 			/**


### PR DESCRIPTION
If `WP_Image_Editor_Imagick::_save()` returns a `WP_Error` but no temp filename exists the `WP_Error` should still be returned. This prevents a fatal error `Cannot use object of type WP_Error as array` for the `$copy_result = copy( $save['path'], $filename );` line.