### PR TITLE
Set a returned value for `get_original_upload_dir`

### DIFF
--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -253,7 +253,7 @@ class Plugin {
 	public function get_original_upload_dir() : array {
 
 		if ( empty( $this->original_upload_dir ) ) {
-			wp_upload_dir();
+			return wp_upload_dir();
 		}
 
 		/**


### PR DESCRIPTION
When `original_upload_dir` is empty make sure the default value
is returned as otherwise no value would be returned.