### PR TITLE
Fix(class-plugin): fix expected return type for get_files_for_unique_filename_file_list

### DIFF
--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -665,6 +665,6 @@ class Plugin {
 		$name = pathinfo( $filename, PATHINFO_FILENAME );
 		// The s3:// streamwrapper support listing by partial prefixes with wildcards.
 		// For example, scandir( s3://bucket/2019/06/my-image* )
-		return scandir( trailingslashit( $dir ) . $name . '*' );
+		return (array) scandir( trailingslashit( $dir ) . $name . '*' );
 	}
 }


### PR DESCRIPTION
Currently there is an error coming up on the function get_files_for_unique_filename_file_list when the input is somehow unexpected and the native php scandir returns FALSE on error. This causes a fatal of course due to the return type on the patent method. 