### PR TITLE
Improve media library performance in some situations

### DIFF
--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -188,7 +188,7 @@ class Plugin {
 				// The s3:// protocol is not needed when displaying the media library and slows things down in some cases.
 				if ( isset( $_POST['action'] ) && 'query-attachments' === $_POST['action'] ) {
 					$dirs['path']    = $this->original_upload_dir['path'];
-					$dirs['basedir'] = $this->original_upload_dir['basedir'];;
+					$dirs['basedir'] = $this->original_upload_dir['basedir'];
 				}
 			}
 		}

--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -184,6 +184,12 @@ class Plugin {
 			} else {
 				$dirs['url']     = str_replace( $s3_path, $this->get_s3_url(), $dirs['path'] );
 				$dirs['baseurl'] = str_replace( $s3_path, $this->get_s3_url(), $dirs['basedir'] );
+
+				// The s3:// protocol is not needed when displaying the media library and slows things down in some cases.
+				if ( isset( $_POST['action'] ) && 'query-attachments' === $_POST['action'] ) {
+					$dirs['path']    = $this->original_upload_dir['path'];
+					$dirs['basedir'] = $this->original_upload_dir['basedir'];;
+				}
 			}
 		}
 


### PR DESCRIPTION
Closes #520 
Closes #593 

In my testing on some large sites with hundreds of GBs of images in S3, the long loading times when displaying the media library that issues report are due to the `s3://` protocol in the path, (and likely other plugins inadvertently creating network requests to S3). If I've understood the logic correctly, the `s3://` protocol is only needed when working with the filesystem, and displaying the media library doesn't need to access the filesystem (unless I've missed some important use-case). 

Not having the `s3://` protocol available during the ajax request that displays the media library dramatically improves the performance of the media library without appearing to cause any side effects in my testing.

## To test:
1. Before applying this patch, check the timing of the `admin-ajax` request that fetches the media library data when adding an image block or on the Media screen in WP Admin. In this test, it's 17s for that one request:
<img width="785" alt="Screen Shot 2022-08-12 at 12 33 56 PM" src="https://user-images.githubusercontent.com/7317227/184436538-10a0a184-a176-4192-bbde-ac720dee6554.png">

3. Apply this patch, refresh the page. Verify it takes much less time for the `admin-ajax` request that fetches the media library data and the images still display nicely:
<img width="780" alt="Screen Shot 2022-08-12 at 12 34 22 PM" src="https://user-images.githubusercontent.com/7317227/184436670-50306d8b-5fd1-4de2-87fc-c503cb4da374.png">

4. Test uploading an image. Images should still upload nicely to S3.
