### PR TITLE
Use ListObjectsV2 where applicable

### DIFF
--- a/inc/class-stream-wrapper.php
+++ b/inc/class-stream-wrapper.php
@@ -461,7 +461,7 @@ class Stream_Wrapper {
 				} catch ( S3Exception $e ) {
 					// Maybe this isn't an actual key, but a prefix. Do a prefix
 					// listing of objects to determine.
-					$result = $this->getClient()->listObjects(
+					$result = $this->getClient()->listObjectsV2(
 						[
 							'Bucket'  => $parts['Bucket'],
 							'Prefix'  => rtrim( $parts['Key'], '/' ) . '/',
@@ -615,7 +615,7 @@ class Stream_Wrapper {
 		// the preg_match() call.
 		//
 		// Essentially, wp_unique_filename( my-file.jpg ) doing a `scandir( s3://bucket/2019/04/ )` will actually result in an s3
-		// listObject query for `s3://bucket/2019/04/my-file` which means even if there are millions of files in `2019/04/` we only
+		// listObjectsV2 query for `s3://bucket/2019/04/my-file` which means even if there are millions of files in `2019/04/` we only
 		// return a much smaller subset.
 		//
 		// Anyone reading this far, brace yourselves for a mighty horrible hack.
@@ -635,7 +635,7 @@ class Stream_Wrapper {
 		// Filter our "/" keys added by the console as directories, and ensure
 		// that if a filter function is provided that it passes the filter.
 		$this->objectIterator = \Aws\flatmap(
-			$this->getClient()->getPaginator( 'ListObjects', $op ),
+			$this->getClient()->getPaginator( 'ListObjectsV2', $op ),
 			function ( Result $result ) use ( $filterFn ) {
 				/** @var list<S3ObjectResultArray> */
 				$contentsAndPrefixes = $result->search( '[Contents[], CommonPrefixes[]][]' );
@@ -1087,7 +1087,7 @@ class Stream_Wrapper {
 		// Use a key that adds a trailing slash if needed.
 		$prefix = rtrim( $params['Key'], '/' ) . '/';
 		/** @var array{Contents: list<array{ Key: string }>, CommonPrefixes:array} */
-		$result = $this->getClient()->listObjects(
+		$result = $this->getClient()->listObjectsV2(
 			[
 				'Bucket'  => $params['Bucket'],
 				'Prefix'  => $prefix,

--- a/inc/class-wp-cli-command.php
+++ b/inc/class-wp-cli-command.php
@@ -143,7 +143,7 @@ class WP_CLI_Command extends \WP_CLI_Command {
 
 		try {
 			$objects = $s3->getIterator(
-				'ListObjects', [
+				'ListObjectsV2', [
 					'Bucket' => strtok( S3_UPLOADS_BUCKET, '/' ),
 					'Prefix' => $prefix,
 				]


### PR DESCRIPTION
A recent change in the AWS PHP SDK broke ListUploads with an explicit endpoint URL. Using the V2 version of the method solves the problem and the returned results are compatible with the previous version.

See: https://github.com/aws/aws-sdk-php/issues/2575
See: https://github.com/humanmade/altis-local-server/issues/542