### PR TITLE
Set cache-control header for assets uploaded to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ define( 'S3_UPLOADS_HTTP_EXPIRES', gmdate( 'D, d M Y H:i:s', time() + (10 * 365 
 	// will expire in 10 years time
 ```
 
+If the constant `S3_UPLOADS_HTTP_CACHE_CONTROL` is not set, a default `Cache-Control` header `max-age=31536000` is set on the file.
+
 ## Default Behaviour
 
 As S3 Uploads is a plug and play plugin, activating it will start rewriting image URLs to S3, and also put

--- a/inc/class-stream-wrapper.php
+++ b/inc/class-stream-wrapper.php
@@ -241,7 +241,7 @@ class Stream_Wrapper {
 				$params['CacheControl'] = S3_UPLOADS_HTTP_CACHE_CONTROL;
 			}
 		} else {
-			$params['CacheControl'] = 'max-age=31530000';
+			$params['CacheControl'] = 'max-age=31536000';
 		}
 
 		/**

--- a/inc/class-stream-wrapper.php
+++ b/inc/class-stream-wrapper.php
@@ -240,7 +240,10 @@ class Stream_Wrapper {
 			} else {
 				$params['CacheControl'] = S3_UPLOADS_HTTP_CACHE_CONTROL;
 			}
+		} else {
+			$params['CacheControl'] = 'max-age=31530000';
 		}
+
 
 		/**
 		 * Filter the parameters passed to S3

--- a/inc/class-stream-wrapper.php
+++ b/inc/class-stream-wrapper.php
@@ -244,7 +244,6 @@ class Stream_Wrapper {
 			$params['CacheControl'] = 'max-age=31530000';
 		}
 
-
 		/**
 		 * Filter the parameters passed to S3
 		 * Theses are the parameters passed to S3Client::putObject()


### PR DESCRIPTION
- Sets a default `cache-control` header value of `max-age=31536000` to every file uploaded to S3.

