### PR TITLE
Add composer/installers to allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,10 @@
 	"scripts": {
 		"test": "./tests/run-tests.sh",
 		"check-types": "./vendor/bin/psalm"
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true
+		}
 	}
 }


### PR DESCRIPTION
Composer currently fails to run an installation with the following:

```
Error: composer/installers contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.
```

This commit allows composer/installers to run by adding it to the safe list.

The failure is currently affecting this build action:

https://github.com/humanmade/S3-Uploads/actions/runs/3567321595

I'm not sure why this previous build action succeeds though:

https://github.com/humanmade/S3-Uploads/actions/runs/1922046645/jobs/2727425028