### PR TITLE
Move adding of wp-cli command to init()

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -29,6 +29,10 @@ function init() {
 		wp_die( 'S3_UPLOADS_REGION constant is required. Please define it in your wp-config.php' );
 	}
 
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		\WP_CLI::add_command( 's3-uploads', 'S3_Uploads\\WP_CLI_Command' );
+	}
+
 	$instance = Plugin::get_instance();
 	$instance->setup();
 

--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -11,7 +11,3 @@ Author URI: https://hmn.md
 require_once __DIR__ . '/inc/namespace.php';
 
 add_action( 'plugins_loaded', 'S3_Uploads\\init', 0 );
-
-if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	WP_CLI::add_command( 's3-uploads', 'S3_Uploads\\WP_CLI_Command' );
-}


### PR DESCRIPTION
Makes manual installation work again, like suggested by felipeelia.
https://github.com/humanmade/S3-Uploads/issues/573#issuecomment-1151335081