### PR TITLE
fix additional image sizes paths

### DIFF
--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -551,7 +551,7 @@ class Plugin {
 		$meta = wp_get_attachment_metadata( $attachment_id );
 		if ( isset( $meta['sizes'] ) ) {
 			foreach ( $meta['sizes'] as $size => $sizeinfo ) {
-				$files[] = $uploadpath['basedir'] . $sizeinfo['file'];
+				$files[] = $uploadpath['path'] . '/' . $sizeinfo['file'];
 			}
 		}
 


### PR DESCRIPTION
When trying to update the ACL on my images, I noticed the thumbnails weren't getting updated. While going through the rabbit hole I noticed the S3 batch commands were sending the following keys:

```
array (size=5)
  0 => string 's3://bucket-name/uploads/2023/02/unsplash_waxDxYM2XI4.jpg' (length=63)
  1 => string 's3://bucket-name/uploadsunsplash_waxDxYM2XI4-300x223.jpg' (length=62)
  2 => string 's3://bucket-name/uploadsunsplash_waxDxYM2XI4-1024x760.jpg' (length=63)
  3 => string 's3://bucket-name/uploadsunsplash_waxDxYM2XI4-150x150.jpg' (length=62)
  4 => string 's3://bucket-name/uploadsunsplash_waxDxYM2XI4-768x570.jpg' (length=62)
```

And they should be like this:

```
array (size=5)
  0 => string 's3://bucket-name/uploads/2023/02/unsplash_waxDxYM2XI4.jpg' (length=63)
  1 => string 's3://bucket-name/uploads/2023/02/unsplash_waxDxYM2XI4-300x223.jpg' (length=71)
  2 => string 's3://bucket-name/uploads/2023/02/unsplash_waxDxYM2XI4-1024x760.jpg' (length=72)
  3 => string 's3://bucket-name/uploads/2023/02/unsplash_waxDxYM2XI4-150x150.jpg' (length=71)
  4 => string 's3://bucket-name/uploads/2023/02/unsplash_waxDxYM2XI4-768x570.jpg' (length=71)
```