### PR TITLE
Replace "/" with "\" on windows machines

### DIFF
--- a/inc/class-local-stream-wrapper.php
+++ b/inc/class-local-stream-wrapper.php
@@ -143,7 +143,7 @@ class Local_Stream_Wrapper {
 			$uri = $this->uri;
 		}
 		$path = $this->getDirectoryPath() . '/' . $this->getTarget( $uri );
-		$realpath = $path;
+        $realpath = str_replace( '/', DIRECTORY_SEPARATOR, $path ); // ensure check against realpath passes on Windows machines
 
 		$directory = realpath( $this->getDirectoryPath() );
 

--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -157,7 +157,7 @@ class Plugin {
 	/**
 	 * Get the s3:// path for the bucket.
 	 */
-	public function get_s3_path() {
+	public function get_s3_path() : string {
 		return 's3://' . $this->bucket;
 	}
 


### PR DESCRIPTION
When using the local stream wrapper on Windows machines, need to use "\\" directory separator instead of "/", otherwise `getLocalPath` always returns empty string