### PR TITLE
Backport master branch fixes

### DIFF
--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -157,7 +157,7 @@ class Plugin {
 	/**
 	 * Get the s3:// path for the bucket.
 	 */
-	public function get_s3_path() {
+	public function get_s3_path() : string {
 		return 's3://' . $this->bucket;
 	}
 

--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -673,6 +673,6 @@ class Plugin {
 		$name = pathinfo( $filename, PATHINFO_FILENAME );
 		// The s3:// streamwrapper support listing by partial prefixes with wildcards.
 		// For example, scandir( s3://bucket/2019/06/my-image* )
-		return scandir( trailingslashit( $dir ) . $name . '*' );
+		return (array) scandir( trailingslashit( $dir ) . $name . '*' );
 	}
 }

--- a/inc/class-stream-wrapper.php
+++ b/inc/class-stream-wrapper.php
@@ -486,7 +486,7 @@ class Stream_Wrapper {
 	private function statDirectory( $parts, $path, $flags ) {
 		// Stat "directories": buckets, or "s3://"
 		if ( ! $parts['Bucket'] ||
-			$this->getClient()->doesBucketExist( $parts['Bucket'] )
+			$this->getClient()->doesBucketExistV2( $parts['Bucket'], false )
 		) {
 			return $this->formatUrlStat( $path );
 		}
@@ -816,9 +816,10 @@ class Stream_Wrapper {
 		/** @var string */
 		$key = $this->getOption( 'Key' );
 		if ( $mode == 'x' &&
-			$this->getClient()->doesObjectExist(
+			$this->getClient()->doesObjectExistV2(
 				$bucket,
 				$key,
+				false,
 				$this->getOptions( true )
 			)
 		) {
@@ -1031,7 +1032,7 @@ class Stream_Wrapper {
 	 * @return bool Returns true on success or false on failure
 	 */
 	private function createBucket( $path, array $params ) {
-		if ( $this->getClient()->doesBucketExist( $params['Bucket'] ) ) {
+		if ( $this->getClient()->doesBucketExistV2( $params['Bucket'], false ) ) {
 			return $this->triggerError( "Bucket already exists: {$path}" );
 		}
 
@@ -1058,7 +1059,7 @@ class Stream_Wrapper {
 		$params['Body'] = '';
 
 		// Fail if this pseudo directory key already exists
-		if ( $this->getClient()->doesObjectExist(
+		if ( $this->getClient()->doesObjectExistV2(
 			$params['Bucket'],
 			$params['Key']
 		)


### PR DESCRIPTION
Cherry-picks:

- 76393e1505a376dc3378a674870513364fb13a94 (`Add type to get_s3_path()`)
- 7d9c1148d65446018297970a7a313687b4e1b99f (`Fix build`)
- 8625e77350906588ae564a4b876d8b8da605d0dc (`fix(class-plugin): fix expecte return type for get_files_for_unique_filename_file_list`)

from `master` branch