### PR TITLE
Fixes: Fatal Error when running PHP lint command

### DIFF
--- a/psalm/stubs/imagick.php
+++ b/psalm/stubs/imagick.php
@@ -1,11 +1,13 @@
 <?php
 
-/**
- * @method Imagick clone() (PECL imagick 2.0.0)<br/>Makes an exact copy of the Imagick object
- * @link https://php.net/manual/en/class.imagick.php
- */
-class Imagick implements Iterator, Countable {
+namespace {
+	/**
+	 * @method Imagick clone() (PECL imagick 2.0.0)<br/>Makes an exact copy of the Imagick object
+	 * @link https://php.net/manual/en/class.imagick.php
+	 */
+	class Imagick implements Iterator, Countable {
 
+	}
 }
 
 namespace WP_CLI {


### PR DESCRIPTION
This PR fixes a linting error when running PHP's lint across the Imagick stub file.

When scanning our projects, including the S3 Uploads plugin, it was identified when running the lint command on new PHP versions.

System:
- PHP 7.4|8.0|8.1

Error:

```bash
Fatal error: Namespace declaration statement has to be the very first statement or after any declare call in the script in psalm/stubs/imagick.php on line 11
```

Recreate:
`php -l psalm/stubs/imagick.php`

Expect:
`No syntax errors detected in psalm/stubs/imagick.php`

Another option would be to exclude the `./psalm` directory from being included in the release via the `.gitattributes` file.