### PR TITLE
Use get_temp_dir instead of sys_get_temp_dir

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -146,7 +146,7 @@ function set_wp_privacy_exports_dir( string $dir ) {
 	if ( strpos( $dir, 's3://' ) !== 0 ) {
 		return $dir;
 	}
-	$dir = get_temp_dir() . '/wp_privacy_exports_dir/';
+	$dir = get_temp_dir() . 'wp_privacy_exports_dir/';
 	if ( ! is_dir( $dir ) ) {
 		mkdir( $dir );
 		file_put_contents( $dir . 'index.html', '' ); // @codingStandardsIgnoreLine FS write is ok.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -136,7 +136,7 @@ function after_export_personal_data() {
  *
  * We don't want to use the default uploads folder location, as with S3 Uploads this is
  * going to the a s3:// custom URL handler, which is going to fail with the use of ZipArchive.
- * Instead we set to to sys_get_temp_dir and move the fail in the wp_privacy_personal_data_export_file_created
+ * Instead we set to to WPs get_temp_dir and move the fail in the wp_privacy_personal_data_export_file_created
  * hook.
  *
  * @param string $dir
@@ -146,7 +146,7 @@ function set_wp_privacy_exports_dir( string $dir ) {
 	if ( strpos( $dir, 's3://' ) !== 0 ) {
 		return $dir;
 	}
-	$dir = sys_get_temp_dir() . '/wp_privacy_exports_dir/';
+	$dir = get_temp_dir() . '/wp_privacy_exports_dir/';
 	if ( ! is_dir( $dir ) ) {
 		mkdir( $dir );
 		file_put_contents( $dir . 'index.html', '' ); // @codingStandardsIgnoreLine FS write is ok.
@@ -162,7 +162,7 @@ function set_wp_privacy_exports_dir( string $dir ) {
  * the "natural" Core URL is going to be pointing to.
  */
 function move_temp_personal_data_to_s3( string $archive_pathname ) {
-	if ( strpos( $archive_pathname, sys_get_temp_dir() ) !== 0 ) {
+	if ( strpos( $archive_pathname, get_temp_dir() ) !== 0 ) {
 		return;
 	}
 	$upload_dir = wp_upload_dir();


### PR DESCRIPTION
I had a problem on one of the WordPress installation where directory returned by `sys_get_temp_dir` was not writeable by php and changing `WP_TEMP_DIR` did not help (because the plugin was not taking that into account).  
Changing `sys_get_temp_dir` to Wordpress function `get_temp_dir` helped. 
