### PR TITLE
fix readdir bug from PHP 8 substr change

### DIFF
--- a/inc/class-stream-wrapper.php
+++ b/inc/class-stream-wrapper.php
@@ -724,9 +724,11 @@ class Stream_Wrapper {
 
 		// Remove the prefix from the result to emulate other stream wrappers.
 		$retVal = $this->openedBucketPrefix
-			  ? substr( $result, strlen( $this->openedBucketPrefix ) )
-			  : $result;
-		if ( $retVal === '' ) $retVal = false;
+			? substr( $result, strlen( $this->openedBucketPrefix ) )
+			: $result;
+		if ( $retVal === '' ) {
+			$retVal = false;
+		}
 		return $retVal;
 	}
 

--- a/inc/class-stream-wrapper.php
+++ b/inc/class-stream-wrapper.php
@@ -723,9 +723,11 @@ class Stream_Wrapper {
 		$this->objectIterator->next();
 
 		// Remove the prefix from the result to emulate other stream wrappers.
-		return $this->openedBucketPrefix
-			? substr( $result, strlen( $this->openedBucketPrefix ) )
-			: $result;
+		$retVal = $this->openedBucketPrefix
+			  ? substr( $result, strlen( $this->openedBucketPrefix ) )
+			  : $result;
+		if ( $retVal === '' ) $retVal = false;
+		return $retVal;
 	}
 
 	private function formatKey( string $key ) : string {

--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -4,7 +4,7 @@
 Plugin Name: S3 Uploads
 Description: Store uploads in S3
 Author: Human Made Limited
-Version: 3.0.6
+Version: 3.0.8
 Author URI: https://hmn.md
 */
 


### PR DESCRIPTION
As of PHP 8.0, substr will return empty string rather than false in certain circumstances.

From https://www.php.net/manual/en/function.substr.php : 
8.0.0 	The function returns an empty string where it previously returned false. 

Due to this change, this implementation of readdir in S3-Uploads behaves incorrectly. In particular, this common pattern:
while (($file = readdir($dh)) !== false){
which is used in gravityforms, becomes an infinite loop since the while loop just keeps getting an empty string rather than false.

This can lead to a crazy high AWS S3 list line item on your monthly bill. I recommend merging in this change right away to avoid this situation.