### PR TITLE
Add Stream support for audit logs of all ACL sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Note: as either `<from>` or `<to>` can be S3 or local locations, you must specif
 
 ## Private Uploads
 
-WordPress (and therefor S3 Uploads) default behaviour is that all uploaded media files are publicly accessible. In certain cases which may not be desireable. S3 Uploads supports setting S3 Objects to a `private` ACL and providing temporarily signed URLs for all files that are marked as private.
+WordPress (and therefore S3 Uploads) default behaviour is that all uploaded media files are publicly accessible. In certain cases which may not be desireable. S3 Uploads supports setting S3 Objects to a `private` ACL and providing temporarily signed URLs for all files that are marked as private.
 
 S3 Uploads does not make assumptions or provide UI for marking attachments as private, instead you should integrate the `s3_uploads_is_attachment_private` WordPress filter to control the behaviour. For example, to mark _all_ attachments as private:
 
@@ -147,6 +147,12 @@ The default expiry for all private file URLs is 6 hours. You can modify this by 
 add_filter( 's3_uploads_private_attachment_url_expiry', function ( $expiry ) {
 	return '+1 hour';
 } );
+```
+
+If you're using [Stream](https://wordpress.org/plugins/stream/) for audit logs, S3 Uploads supports logging any setting of ACL for files of an attachment. You can enable this by defining the constant `S3_UPLOADS_ENABLE_AUDIT_LOGGING` to `true` as follows:
+
+```PHP
+define( 'S3_UPLOADS_ENABLE_AUDIT_LOGGING', true );
 ```
 
 ## Cache Control

--- a/inc/audit-logging/namespace.php
+++ b/inc/audit-logging/namespace.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * S3 Uploads Audit Logging.
+ */
+
+namespace S3_Uploads\Audit_Logging;
+
+/**
+ * Bootstrap audit logging.
+ *
+ * @return void
+ */
+function bootstrap(): void {
+	if ( ! defined( 'S3_UPLOADS_ENABLE_AUDIT_LOGGING' ) || ! S3_UPLOADS_ENABLE_AUDIT_LOGGING ) {
+		return;
+	}
+
+	require_once __DIR__ . '/stream/namespace.php';
+
+	Stream\bootstrap();
+}

--- a/inc/audit-logging/stream/class-connector.php
+++ b/inc/audit-logging/stream/class-connector.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Connector to log Stream S3 Uploads events.
+ *
+ * @package S3_Uploads\Audit_Logging\Stream
+ */
+
+namespace S3_Uploads\Audit_Logging\Stream;
+
+class Connector extends \WP_Stream\Connector {
+	/**
+	 * "Set" action slug.
+	 */
+	const ACTION_SET = 'set';
+
+	/**
+	 * "ACL" context slug.
+	 */
+	const CONTEXT_ACL = 'acl';
+
+	/**
+	 * Connector slug.
+	 *
+	 * @var string
+	 */
+	public $name = 's3-uploads';
+
+	/**
+	 * Actions registered for this connector.
+	 *
+	 * These are actions (WordPress hooks) that the connector will listen to.
+	 * Whenever an action from this list is triggered, Stream will run a callback
+	 * function defined in the connector class.
+	 *
+	 * The callback function names follow the format: `callback_{action_name}`.
+	 *
+	 * @var array
+	 */
+	public $actions = [
+		's3_uploads_set_attachment_files_acl',
+	];
+
+	/**
+	 * Return translated connector label.
+	 *
+	 * @return string
+	 */
+	public function get_label() {
+		return __( 'S3 Uploads', 's3-uploads' );
+	}
+
+	/**
+	 * Return translated context labels.
+	 *
+	 * @return array
+	 */
+	public function get_context_labels() {
+		return [
+			self::CONTEXT_ACL => __( 'ACL', 's3-uploads' ),
+		];
+	}
+
+	/**
+	 * Return translated action labels.
+	 *
+	 * @return array
+	 */
+	public function get_action_labels() {
+		return [
+			self::ACTION_SET => __( 'Set', 's3-uploads' ),
+		];
+	}
+
+	/**
+	 * Track `s3_uploads_set_attachment_files_acl` action and log Stream ACL sets.
+	 *
+	 * @param int $attachment_id Attachment whose ACL has been changed.
+	 * @param string $acl The new ACL that's been set.
+	 *
+	 * @return void
+	 */
+	public function callback_s3_uploads_set_attachment_files_acl( int $attachment_id, string $acl ): void {
+		$this->log(
+			__( 'ACL of files for attachment "%1$d" was set to "%2$s"', 's3-uploads' ),
+			// This array will be compacted and saved as Stream meta.
+			[
+				'attachment_id' => $attachment_id,
+				'acl' => $acl,
+			],
+			$attachment_id,
+			self::CONTEXT_ACL,
+			self::ACTION_SET,
+		);
+	}
+}

--- a/inc/audit-logging/stream/namespace.php
+++ b/inc/audit-logging/stream/namespace.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * S3 Uploads Audit Logging using Stream.
+ */
+
+namespace S3_Uploads\Audit_Logging\Stream;
+
+/**
+ * Bootstrap Stream audit logging.
+ *
+ * @return void
+ */
+function bootstrap(): void {
+	if ( ! class_exists( 'WP_Stream\\Plugin' ) ) {
+		return;
+	}
+
+	add_filter( 'wp_stream_connectors', __NAMESPACE__ . '\\register_connector' );
+}
+
+/**
+ * Register the connectors.
+ *
+ * @param array $classes Array of connector class names.
+ *
+ * @return array
+ */
+function register_connector( array $classes ): array {
+	require plugin_dir_path( __FILE__ ) . '/class-connector.php';
+
+	$classes['s3uploads'] = new Connector();
+
+	return $classes;
+}

--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -533,6 +533,14 @@ class Plugin {
 			return new WP_Error( $e->getCode(), $e->getMessage() );
 		}
 
+		/**
+		 * Fires after ACL of files of an attachment is set.
+		 *
+		 * @param int $attachment_id Attachment whose ACL has been changed.
+		 * @param string $acl The new ACL that's been set.
+		 */
+		do_action( 's3_uploads_set_attachment_files_acl', $attachment_id, $acl );
+
 		return null;
 	}
 

--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -9,5 +9,7 @@ Author URI: https://hmn.md
 */
 
 require_once __DIR__ . '/inc/namespace.php';
+require_once __DIR__ . '/inc/audit-logging/namespace.php';
 
 add_action( 'plugins_loaded', 'S3_Uploads\\init', 0 );
+add_action( 'plugins_loaded', 'S3_Uploads\\Audit_Logging\\bootstrap', 11 );


### PR DESCRIPTION
Add [Stream](https://wordpress.org/plugins/stream/) support for audit logs of all ACL sets done by S3 Uploads to files of an attachment. This will help when any investigations need to be done in regards to why an attachment's files have a certain ACL.

We can add support for more audit logging WordPress plugins if there's a need. Starting with support for Stream as such a need has come up and instead of doing an integration solely in the projects that have that need, doing it in S3 Uploads allows others to benefit.

The audit logging feature is opt in and will only work if Stream plugin is activated.