### PR TITLE
Fix implicit nullable parameter deprecations in PHP 8.4

### DIFF
--- a/inc/class-local-stream-wrapper.php
+++ b/inc/class-local-stream-wrapper.php
@@ -90,7 +90,7 @@ class Local_Stream_Wrapper {
 	 * @param array{extensions?: string[], mimetypes: array<string,string>} $mapping
 	 * @return string
 	 */
-	static function getMimeType( string $uri, array $mapping = null ) : string {
+	static function getMimeType( string $uri, ?array $mapping = null ) : string {
 
 		$extension = '';
 		$file_parts = explode( '.', basename( $uri ) );

--- a/inc/class-stream-wrapper.php
+++ b/inc/class-stream-wrapper.php
@@ -119,7 +119,7 @@ class Stream_Wrapper {
 	public static function register(
 		Plugin $plugin,
 		$protocol = 's3',
-		CacheInterface $cache = null
+		?CacheInterface $cache = null
 	) {
 		if ( in_array( $protocol, stream_get_wrappers() ) ) {
 			stream_wrapper_unregister( $protocol );


### PR DESCRIPTION
Just two small, one character fixes for [PHP 8.4's deprecated notice around implicit nulls](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types).

```
PHP Deprecated:  S3_Uploads\Stream_Wrapper::register(): Implicitly marking parameter $cache as nullable is deprecated, the explicit nullable type must be used instead in /plugins/s3-uploads/inc/class-stream-wrapper.php on line 119
```

This fix should be compatible all the way back to PHP 7.1