### PR TITLE
feat: directory rename

### DIFF
--- a/inc/class-stream-wrapper.php
+++ b/inc/class-stream-wrapper.php
@@ -769,23 +769,18 @@ class Stream_Wrapper {
 				$client = $this->getClient();
 				$acl = isset( $options['acl'] ) ? $options['acl'] : 'private';
 
-				// Normalize keys - ensure trailing slash for directories
+				// Normalize keys - remove trailing slashes
 				$from_key = rtrim( $parts_from['Key'], '/' );
 				$to_key = rtrim( $parts_to['Key'], '/' );
 
-				$existsAsFile = $client->doesObjectExistV2(
-					$parts_from['Bucket'],
-					$parts_from['Key'],
-					false,
-					$options
-				);
-
-				$isDirectory = ! $existsAsFile && $this->isDirectoryPrefix( $parts_from['Bucket'], $from_key );
+				$isDirectory = $this->isDirectoryPrefix( $parts_from['Bucket'], $from_key );
 
 				if ( $isDirectory ) {
 					return $this->renameDirectory( $client, $parts_from, $parts_to, $from_key, $to_key, $acl, $options );
 				}
 
+				$parts_from['Key'] = $from_key;
+				$parts_to['Key'] = $to_key;
 				return $this->renameFile( $client, $parts_from, $parts_to, $acl, $options );
 			}
 		);
@@ -850,22 +845,6 @@ class Stream_Wrapper {
 				$cache_keys_to_clear[] = "{$this->protocol}://{$parts_from['Bucket']}/{$old_key}";
 				$cache_keys_to_clear[] = "{$this->protocol}://{$parts_to['Bucket']}/{$new_key}";
 			}
-		}
-
-		// Handle directory marker (empty object with key ending in "/") if it exists
-		$directory_marker_key = $from_prefix;
-		if ( $client->doesObjectExistV2( $parts_from['Bucket'], $directory_marker_key, false, $options ) ) {
-			$directory_marker_new_key = $to_prefix;
-			$copy_commands[] = $client->getCommand( 'CopyObject', [
-				'Bucket'     => $parts_to['Bucket'],
-				'Key'        => $directory_marker_new_key,
-				'CopySource' => $this->encodeCopySource( $parts_from['Bucket'], $directory_marker_key ),
-				'ACL'        => $acl,
-			] + $options );
-
-			$objects_to_delete[] = [ 'Key' => $directory_marker_key ];
-			$cache_keys_to_clear[] = "{$this->protocol}://{$parts_from['Bucket']}/{$directory_marker_key}";
-			$cache_keys_to_clear[] = "{$this->protocol}://{$parts_to['Bucket']}/{$directory_marker_new_key}";
 		}
 
 		if ( empty( $copy_commands ) ) {

--- a/inc/class-stream-wrapper.php
+++ b/inc/class-stream-wrapper.php
@@ -763,8 +763,8 @@ class Stream_Wrapper {
 
 		if ( $partsFrom['Key'] === null || $partsFrom['Key'] === '' || $partsTo['Key'] === null || $partsTo['Key'] === '' ) {
 			return $this->triggerError(
-				'The Amazon S3 stream wrapper only '
-				. 'supports copying objects'
+				'Renaming a bucket root is not supported. '
+				. 'You must specify a path in the form of s3://bucket/key'
 			);
 		}
 
@@ -796,8 +796,8 @@ class Stream_Wrapper {
 	 * Uses batch operations for better S3 performance.
 	 *
 	 * @param S3ClientInterface $client    S3 client instance
-	 * @param array{Bucket: string, Key: string} $parts_from Source path parts
-	 * @param array{Bucket: string, Key: string} $parts_to   Destination path parts
+	 * @param array{Bucket: string, Key: string, ...} $parts_from Source path parts
+	 * @param array{Bucket: string, Key: string, ...} $parts_to   Destination path parts
 	 * @param string            $from_key   Normalized source key
 	 * @param string            $to_key     Normalized destination key
 	 * @param string            $acl       ACL for copied objects
@@ -884,8 +884,8 @@ class Stream_Wrapper {
 	 * Rename a single file by copying and then deleting the original.
 	 *
 	 * @param S3ClientInterface $client    S3 client instance
-	 * @param array{Bucket: string, Key: string} $parts_from Source path parts
-	 * @param array{Bucket: string, Key: string} $parts_to   Destination path parts
+	 * @param array{Bucket: string, Key: string, ...} $parts_from Source path parts
+	 * @param array{Bucket: string, Key: string, ...} $parts_to   Destination path parts
 	 * @param string            $acl       ACL for copied object
 	 * @param array             $options   Additional S3 options
 	 * @return bool True on success
@@ -1257,7 +1257,8 @@ class Stream_Wrapper {
 			'MaxKeys' => 1,
 		] );
 
-		return ! empty( $result['Contents'] ) || ! empty( $result['CommonPrefixes'] );
+		return ( is_array( $result['Contents'] ) && count( $result['Contents'] ) > 0 )
+			|| ( is_array( $result['CommonPrefixes'] ) && count( $result['CommonPrefixes'] ) > 0 );
 	}
 
 	/**

--- a/tests/test-s3-uploads-stream-wrapper.php
+++ b/tests/test-s3-uploads-stream-wrapper.php
@@ -242,4 +242,98 @@ class Test_S3_Uploads_Stream_Wrapper extends WP_UnitTestCase {
 			$this->assertFalse( file_exists( $original_file ), "Original file {$file} should not exist" );
 		}
 	}
+
+	public function test_encode_copy_source_encodes_file_names() {
+		$wrapper = new S3_Uploads\Stream_Wrapper();
+		$reflection = new ReflectionClass( $wrapper );
+		$method = $reflection->getMethod( 'encodeCopySource' );
+		$method->setAccessible( true );
+
+		$bucket = 'test-bucket';
+
+		// Test 1: File with spaces (the main problematic case)
+		$key1 = 'Vector Strips Module I with expressions 2_Page_1.jpg';
+		$result1 = $method->invoke( $wrapper, $bucket, $key1 );
+		$this->assertStringContainsString( '%20', $result1, 'Spaces must be URL-encoded as %20' );
+		$this->assertStringNotContainsString( ' ', $result1, 'CopySource should not contain unencoded spaces' );
+		$expected1 = 'test-bucket/Vector%20Strips%20Module%20I%20with%20expressions%202_Page_1.jpg';
+		$this->assertEquals( $expected1, $result1, 'CopySource must have spaces properly encoded' );
+
+		// Test 2: File with special characters (parentheses)
+		$key2 = 'file with spaces (1).txt';
+		$result2 = $method->invoke( $wrapper, $bucket, $key2 );
+		$this->assertStringContainsString( '%28', $result2, 'Opening parenthesis must be encoded' );
+		$this->assertStringContainsString( '%29', $result2, 'Closing parenthesis must be encoded' );
+		$this->assertStringNotContainsString( '(', $result2, 'CopySource should not contain unencoded opening parenthesis' );
+		$this->assertStringNotContainsString( ')', $result2, 'CopySource should not contain unencoded closing parenthesis' );
+
+		// Test 3: File in subdirectory - slashes must be preserved
+		$key3 = 'subdir/file with spaces.txt';
+		$result3 = $method->invoke( $wrapper, $bucket, $key3 );
+		$this->assertStringContainsString( '/', $result3, 'Slashes must be preserved in CopySource' );
+		$this->assertStringNotContainsString( '%2F', $result3, 'Slashes must NOT be encoded as %2F' );
+		$this->assertStringContainsString( '%20', $result3, 'Spaces in path segments must be encoded' );
+	}
+
+	/**
+	 * @note Amazon minio does not replicates the issue with naming files but it happens in AWS S3.
+	 */
+	public function test_rename_directory_implementation_uses_encode_copy_source() {
+		// Read the source code to verify encodeCopySource is used
+		$source_file = dirname( dirname( __FILE__ ) ) . '/inc/class-stream-wrapper.php';
+		$source_code = file_get_contents( $source_file );
+		
+		// Find the renameDirectory method
+		$rename_directory_start = strpos( $source_code, 'private function renameDirectory' );
+		$this->assertNotFalse( $rename_directory_start, 'renameDirectory method must exist' );
+		
+		// Find the end of the method (next private/public function or closing brace at class level)
+		$method_code = substr( $source_code, $rename_directory_start );
+		$next_function = strpos( $method_code, "\n\tprivate function " );
+		$next_public = strpos( $method_code, "\n\tpublic function " );
+		$end_pos = false;
+		if ( $next_function !== false ) {
+			$end_pos = $next_function;
+		}
+		if ( $next_public !== false && ( $end_pos === false || $next_public < $end_pos ) ) {
+			$end_pos = $next_public;
+		}
+		if ( $end_pos !== false ) {
+			$method_code = substr( $method_code, 0, $end_pos );
+		}
+		
+		// Verify encodeCopySource is called in the method
+		$this->assertStringContainsString( 
+			'encodeCopySource', 
+			$method_code, 
+			'renameDirectory must call encodeCopySource for CopySource parameter. Without this, files with spaces will fail.'
+		);
+		
+		// Verify it's used for the CopySource parameter, not just mentioned
+		$this->assertStringContainsString( 
+			"'CopySource' => \$this->encodeCopySource", 
+			$method_code, 
+			'CopySource parameter must use encodeCopySource method'
+		);
+	}
+
+	/**
+	 * @note Amazon minio does not replicates the issue with naming files but it happens in AWS S3.
+	 */
+	public function test_rename_file_implementation_consistency() {
+		// This test ensures we're aware of how single file renames work
+		// The copy() method may handle encoding, but directory renames definitely need it
+		$upload_dir = wp_upload_dir();
+		$test_file = $upload_dir['path'] . '/Vector Strips Module I with expressions 2_Page_1.jpg';
+		$renamed_file = $upload_dir['path'] . '/Vector Strips Module I with expressions 2_Page_1_renamed.jpg';
+
+		// Create and rename the file
+		file_put_contents( $test_file, 'test content' );
+		$result = rename( $test_file, $renamed_file );
+		
+		// This should work - if it doesn't, there's a problem
+		$this->assertTrue( $result, 'File rename with spaces should succeed' );
+		$this->assertTrue( file_exists( $renamed_file ), 'Renamed file should exist' );
+		$this->assertFalse( file_exists( $test_file ), 'Original file should not exist' );
+	}
 }


### PR DESCRIPTION

This pull request significantly enhances the S3 stream wrapper by adding robust support for renaming directories (not just files) within S3 buckets, ensuring correct handling of special characters in object keys (such as spaces and parentheses), and improving test coverage for these scenarios. The update introduces batch operations for efficient directory renames and adds comprehensive tests to verify correct behavior and encoding.

**Major enhancements to S3 stream wrapper directory rename functionality:**

* Added support for renaming directories (not just single files) by recursively copying all objects under the source prefix to the new destination, then deleting the originals, using AWS S3 batch operations for efficiency. This includes handling directory markers and cache invalidation.
* Implemented the `isDirectoryPrefix` helper to accurately detect when a given key represents a directory (prefix) in S3, ensuring the correct rename logic is applied.
* Introduced the `encodeCopySource` method to correctly URL-encode each path segment for S3's `CopySource` parameter, preventing failures when object keys contain spaces or special characters.

**Test improvements and validation:**

* Added extensive tests for directory renaming, including cases with nested files, empty directories, and files with special characters in their names, to ensure the new logic works as intended.
* Included tests to verify that the `encodeCopySource` method is used in the directory rename implementation and that file renames with special characters succeed.

**Dependency update:**

* Added import of `Aws\CommandPool` to enable batch operations for copying objects in directory renames.