### PR TITLE
Update classmap path in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	],
 	"license": "GPL-2.0+",
 	"autoload": {
-		"classmap": [ "./inc" ]
+		"classmap": [ "inc/" ]
 	},
 	"authors": [
 		{


### PR DESCRIPTION
This fixes the warning generated by composer 2.9 when running `composer install` or `composer update`:

```
Could not scan for classes inside "content/plugins/s3-uploads//./inc" which does not appear to be a file nor a folder
```