### PR TITLE
Fix test setup for modern Minio compatibility

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,7 +18,8 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 
 tests_add_filter( 's3_uploads_s3_client_params', function ( array $params ) : array {
-	$params['endpoint'] = 'http://172.17.0.2:9000';
+	$params['endpoint'] = 'http://minio:9000';
+	$params['use_path_style_endpoint'] = true;
 	return $params;
 } );
 
@@ -37,5 +38,7 @@ if ( getenv( 'S3_UPLOADS_SECRET' ) ) {
 if ( getenv( 'S3_UPLOADS_REGION' ) ) {
 	define( 'S3_UPLOADS_REGION', getenv( 'S3_UPLOADS_REGION' ) );
 }
+
+define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', dirname( __DIR__ ) . '/vendor/yoast/phpunit-polyfills' );
 
 require '/wp-phpunit/includes/bootstrap.php';

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -6,11 +6,19 @@ else
 	mkdir /tmp/s3-uploads-tests
 fi
 
-mkdir /tmp/s3-uploads-tests/tests
+docker run --rm --name s3-uploads-tests-minio -d -p 9000:9000 -e MINIO_ROOT_USER=AWSACCESSKEY -e MINIO_ROOT_PASSWORD=AWSSECRETKEY minio/minio server /data > /dev/null
 
-docker run --rm --name s3-uploads-tests-minio -d --rm -p 9000:9000 -e MINIO_ACCESS_KEY=AWSACCESSKEY -e MINIO_SECRET_KEY=AWSSECRETKEY -v /tmp/s3-uploads-tests:/data minio/minio server /data > /dev/null
+# Wait for Minio to be ready, then create the 'tests' bucket
+echo "Waiting for Minio to start..."
+for i in $(seq 1 30); do
+	if docker run --rm --link s3-uploads-tests-minio:minio --entrypoint=/bin/sh minio/minio -c "mc alias set myminio http://minio:9000 AWSACCESSKEY AWSSECRETKEY && mc mb --ignore-existing myminio/tests" > /dev/null 2>&1; then
+		echo "Minio ready, 'tests' bucket created."
+		break
+	fi
+	sleep 1
+done
 
-docker run --rm -e AWS_SUPPRESS_PHP_DEPRECATION_WARNING=1 -e S3_UPLOADS_BUCKET=tests -e S3_UPLOADS_KEY=AWSACCESSKEY -e S3_UPLOADS_SECRET=AWSSECRETKEY -e S3_UPLOADS_REGION=us-east-1 -v $PWD:/code humanmade/plugin-tester $@
+docker run --rm -e AWS_SUPPRESS_PHP_DEPRECATION_WARNING=1 -e S3_UPLOADS_BUCKET=tests -e S3_UPLOADS_KEY=AWSACCESSKEY -e S3_UPLOADS_SECRET=AWSSECRETKEY -e S3_UPLOADS_REGION=us-east-1 --link s3-uploads-tests-minio:minio -v $PWD:/code humanmade/plugin-tester $@
 docker kill s3-uploads-tests-minio > /dev/null
 
 echo "Running Psalm..."


### PR DESCRIPTION
## Summary

In preparation for upgrading the old version of `aws-sdk-php` (see [PR 659](https://github.com/humanmade/S3-Uploads/pull/659), I brought the tests back into a working state.
For now, still sticking with Minio. 

- Update `run-tests.sh` to use current Minio env vars (`MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD`) replacing deprecated `MINIO_ACCESS_KEY`/`MINIO_SECRET_KEY`
- Create the `tests` bucket via `mc` CLI instead of relying on filesystem directories, which no longer works with modern Minio
- Use Docker `--link` for container networking and hostname `minio` instead of hardcoded Docker bridge IP `172.17.0.2`
- Add `use_path_style_endpoint` to S3 client params to avoid virtual hosted-style URLs that Minio can't resolve
- Set `WP_TESTS_PHPUNIT_POLYFILLS_PATH` constant required by the newer WP test suite

## Test plan

- [x] Ran `composer test` locally — all 27 tests pass with 0 errors