### PR TITLE
Implement bypass rules for S3 uploads

### DIFF
--- a/inc/class-file-bypass.php
+++ b/inc/class-file-bypass.php
@@ -119,4 +119,20 @@ class File_Bypass {
 		}
 		return null;
 	}
+
+	/**
+	 * Return the first bypass rule matching a directory path or its descendants.
+	 *
+	 * Rules are commonly written as descendant globs (e.g. *\/redux/*). Directory
+	 * operations like opendir() and mkdir() receive the directory itself
+	 * (e.g. s3://bucket/uploads/redux), so also try the same path with a trailing slash.
+	 *
+	 * @param string $path Full S3 directory path.
+	 * @return array|null
+	 * @psalm-return array{pattern: string, action: string, target?: string}|null
+	 */
+	public static function match_directory( string $path ) : ?array {
+		$path = rtrim( $path, '/' );
+		return self::match( $path ) ?: self::match( $path . '/' );
+	}
 }

--- a/inc/class-file-bypass.php
+++ b/inc/class-file-bypass.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace S3_Uploads;
+
+/**
+ * File bypass rules for S3 Uploads.
+ *
+ * Allows certain file paths to bypass S3 operations entirely, avoiding
+ * unnecessary latency and cost from WordPress plugins that constantly
+ * read/write irrelevant files (e.g. .htaccess, index.html, index.php).
+ *
+ * Configuration via PHP constants in wp-config.php:
+ *
+ * Simple shorthand — all matched files use 'void' action:
+ *   define( 'S3_UPLOADS_BYPASS_PATTERNS', '*.htaccess,*\/index.html,*\/index.php' );
+ *
+ * Full rules with per-rule actions:
+ *   define( 'S3_UPLOADS_BYPASS_RULES', [
+ *       [ 'pattern' => '*.htaccess',    'action' => 'void' ],
+ *       [ 'pattern' => '*\/index.html',  'action' => 'void' ],
+ *       [ 'pattern' => '*\/index.php',   'action' => 'exists' ],
+ *       [ 'pattern' => '*\/cache/*.txt', 'action' => 'local' ],
+ *       [ 'pattern' => '*\/cache/*.php', 'action' => 'local', 'target' => '/tmp/wp-bypass' ],
+ *   ] );
+ *
+ * Actions:
+ *   - 'void'   : Operations succeed silently but nothing is stored. file_exists() returns false.
+ *   - 'exists' : Operations succeed silently but nothing is stored. file_exists() returns true.
+ *   - 'local'  : Redirect read/write to the local filesystem. Uses the original WordPress upload
+ *                directory by default, or a custom path via the 'target' key in the rule.
+ *
+ * Both constants can be defined simultaneously; S3_UPLOADS_BYPASS_RULES is applied first.
+ */
+class File_Bypass {
+
+	/**
+	 * Cached bypass rules.
+	 *
+	 * @var array[]|null
+	 * @psalm-var list<array{pattern: string, action: string, target?: string}>|null
+	 */
+	private static $rules = null;
+
+	/**
+	 * Get all configured bypass rules.
+	 *
+	 * Rules are loaded from constants and the `s3_uploads_bypass_rules` filter, then cached
+	 * for the remainder of the request. Call reset() to clear the cache (e.g. in tests).
+	 *
+	 * @return array[]
+	 * @psalm-return list<array{pattern: string, action: string, target?: string}>
+	 */
+	public static function get_rules() : array {
+		if ( self::$rules !== null ) {
+			return self::$rules;
+		}
+
+		/** @psalm-var list<array{pattern: string, action: string, target?: string}> $rules */
+		$rules = [];
+
+		if ( defined( 'S3_UPLOADS_BYPASS_RULES' ) && is_array( S3_UPLOADS_BYPASS_RULES ) ) {
+			/** @psalm-var list<array{pattern: string, action: string, target?: string}> $defined_rules */
+			$defined_rules = S3_UPLOADS_BYPASS_RULES;
+			$rules = $defined_rules;
+		}
+
+		if ( defined( 'S3_UPLOADS_BYPASS_PATTERNS' ) && is_string( S3_UPLOADS_BYPASS_PATTERNS ) && S3_UPLOADS_BYPASS_PATTERNS ) {
+			foreach ( explode( ',', (string) S3_UPLOADS_BYPASS_PATTERNS ) as $pattern ) {
+				$pattern = trim( $pattern );
+				if ( $pattern !== '' ) {
+					$rules[] = [ 'pattern' => $pattern, 'action' => 'void' ];
+				}
+			}
+		}
+
+		/**
+		 * Filter the list of file bypass rules.
+		 *
+		 * This runs after constants are loaded, allowing rules to be added or replaced
+		 * programmatically (useful for testing and for mu-plugins that cannot use constants).
+		 *
+		 * @param array[] $rules Existing rules from S3_UPLOADS_BYPASS_RULES / S3_UPLOADS_BYPASS_PATTERNS.
+		 * @return array[]
+		 */
+		if ( function_exists( 'apply_filters' ) ) {
+			/** @psalm-var list<array{pattern: string, action: string, target?: string}> $rules */
+			$rules = apply_filters( 's3_uploads_bypass_rules', $rules );
+		}
+
+		self::$rules = $rules;
+		return $rules;
+	}
+
+	/**
+	 * Clear the cached rules so they are reloaded on the next call to get_rules().
+	 *
+	 * Intended for use in tests and when rules need to be refreshed at runtime.
+	 */
+	public static function reset() : void {
+		self::$rules = null;
+	}
+
+	/**
+	 * Return the first bypass rule matching the given S3 path, or null.
+	 *
+	 * Matching is attempted against both the full path (e.g. s3://bucket/uploads/2024/.htaccess)
+	 * and the basename only (e.g. .htaccess), so simple patterns like '*.htaccess' work without
+	 * needing to include the full path prefix.
+	 *
+	 * @param string $path Full S3 path (e.g. s3://bucket/path/to/file).
+	 * @return array|null
+	 * @psalm-return array{pattern: string, action: string, target?: string}|null
+	 */
+	public static function match( string $path ) : ?array {
+		foreach ( self::get_rules() as $rule ) {
+			if ( fnmatch( $rule['pattern'], $path ) || fnmatch( $rule['pattern'], basename( $path ) ) ) {
+				return $rule;
+			}
+		}
+		return null;
+	}
+}

--- a/inc/class-stream-wrapper.php
+++ b/inc/class-stream-wrapper.php
@@ -599,6 +599,21 @@ class Stream_Wrapper {
 	 */
 	public function mkdir( string $path, int $mode, $options ) : bool {
 		$this->initProtocol( $path );
+		/** @psalm-var array{pattern: string, action: string, target?: string}|null $bypass */
+		$bypass = File_Bypass::match_directory( $path );
+		if ( $bypass ) {
+			if ( in_array( $bypass['action'], [ 'void', 'exists' ], true ) ) {
+				return true;
+			}
+			if ( $bypass['action'] === 'local' ) {
+				$local_path = $this->getLocalBypassPath( $path, $bypass );
+				if ( $local_path === null ) {
+					return false;
+				}
+				return wp_mkdir_p( $local_path );
+			}
+		}
+
 		$params = $this->withPath( $path );
 		$this->clearCacheKey( $path );
 		if ( ! $params['Bucket'] ) {
@@ -621,6 +636,22 @@ class Stream_Wrapper {
 	 */
 	public function rmdir( string $path, $options ) : bool {
 		$this->initProtocol( $path );
+		/** @psalm-var array{pattern: string, action: string, target?: string}|null $bypass */
+		$bypass = File_Bypass::match_directory( $path );
+		if ( $bypass ) {
+			if ( in_array( $bypass['action'], [ 'void', 'exists' ], true ) ) {
+				return true;
+			}
+			if ( $bypass['action'] === 'local' ) {
+				$local_path = $this->getLocalBypassPath( $path, $bypass );
+				if ( $local_path === null ) {
+					return true;
+				}
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				return ! is_dir( $local_path ) || @rmdir( $local_path );
+			}
+		}
+
 		$this->clearCacheKey( $path );
 		$params = $this->withPath( $path );
 		$client = $this->getClient();
@@ -659,6 +690,29 @@ class Stream_Wrapper {
 		$this->initProtocol( $path );
 		$this->openedPath = $path;
 		$params = $this->withPath( $path );
+		/** @psalm-var array{pattern: string, action: string, target?: string}|null $bypass */
+		$bypass = File_Bypass::match_directory( $path );
+		if ( $bypass ) {
+			$this->openedBucket = $params['Bucket'];
+			$this->openedBucketPrefix = ( $params['Key'] !== null && $params['Key'] !== '' )
+				? rtrim( $params['Key'], '/' ) . '/'
+				: '';
+
+			if ( in_array( $bypass['action'], [ 'void', 'exists' ], true ) ) {
+				$this->objectIterator = new \ArrayIterator( [] );
+				return true;
+			}
+
+			if ( $bypass['action'] === 'local' ) {
+				$local_path = $this->getLocalBypassPath( $path, $bypass );
+				if ( $local_path === null ) {
+					return false;
+				}
+				$this->objectIterator = $this->getLocalBypassDirectoryIterator( $local_path, $params );
+				return true;
+			}
+		}
+
 		/** @var string|null */
 		$delimiter = $this->getOption( 'delimiter' );
 		/** @var callable|null $filterFn */
@@ -840,6 +894,34 @@ class Stream_Wrapper {
 		// PHP will not allow rename across wrapper types, so we can safely
 		// assume $path_from and $path_to have the same protocol
 		$this->initProtocol( $path_from );
+		/** @psalm-var array{pattern: string, action: string, target?: string}|null $from_bypass */
+		$from_bypass = File_Bypass::match( $path_from ) ?: File_Bypass::match_directory( $path_from );
+		/** @psalm-var array{pattern: string, action: string, target?: string}|null $to_bypass */
+		$to_bypass = File_Bypass::match( $path_to ) ?: File_Bypass::match_directory( $path_to );
+
+		if ( $from_bypass || $to_bypass ) {
+			if ( ! $from_bypass || ! $to_bypass ) {
+				return true;
+			}
+
+			if ( in_array( $from_bypass['action'], [ 'void', 'exists' ], true )
+				|| in_array( $to_bypass['action'], [ 'void', 'exists' ], true )
+			) {
+				return true;
+			}
+
+			if ( $from_bypass['action'] === 'local' && $to_bypass['action'] === 'local' ) {
+				$local_from = $this->getLocalBypassPath( $path_from, $from_bypass );
+				$local_to = $this->getLocalBypassPath( $path_to, $to_bypass );
+				if ( $local_from === null || $local_to === null ) {
+					return false;
+				}
+				wp_mkdir_p( dirname( $local_to ) );
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				return @rename( $local_from, $local_to );
+			}
+		}
+
 		$partsFrom = $this->withPath( $path_from );
 		$partsTo = $this->withPath( $path_to );
 		$this->clearCacheKey( $path_from );
@@ -1257,6 +1339,54 @@ class Stream_Wrapper {
 		}
 
 		return $local;
+	}
+
+	/**
+	 * Build an S3-like directory iterator from a local bypass directory.
+	 *
+	 * @param string $local_path Local filesystem directory path.
+	 * @param array  $params     Bucket/key options for the opened S3 directory.
+	 * @psalm-param array{Bucket: string, Key: string|null} $params
+	 * @return \Iterator
+	 */
+	private function getLocalBypassDirectoryIterator( string $local_path, array $params ) : \Iterator {
+		if ( ! is_dir( $local_path ) ) {
+			return new \ArrayIterator( [] );
+		}
+
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		$entries = @scandir( $local_path );
+		if ( $entries === false ) {
+			return new \ArrayIterator( [] );
+		}
+
+		$key_prefix = $params['Key'] !== null && $params['Key'] !== ''
+			? rtrim( $params['Key'], '/' ) . '/'
+			: '';
+		$results = [];
+
+		foreach ( $entries as $entry ) {
+			if ( $entry === '.' || $entry === '..' ) {
+				continue;
+			}
+
+			$entry_path = rtrim( $local_path, '/' ) . '/' . $entry;
+			$key = $key_prefix . $entry;
+
+			if ( is_dir( $entry_path ) ) {
+				$results[] = [ 'Prefix' => $key . '/' ];
+				continue;
+			}
+
+			$mtime = filemtime( $entry_path );
+			$results[] = [
+				'Key'          => $key,
+				'Size'         => filesize( $entry_path ) ?: 0,
+				'LastModified' => gmdate( 'c', $mtime !== false ? $mtime : time() ),
+			];
+		}
+
+		return new \ArrayIterator( $results );
 	}
 
 	/**

--- a/inc/class-stream-wrapper.php
+++ b/inc/class-stream-wrapper.php
@@ -110,6 +110,12 @@ class Stream_Wrapper {
 	private $protocol = 's3';
 
 	/**
+	 * @var array|null Active bypass rule for the current stream, or null if none.
+	 * @psalm-var array{pattern: string, action: string, target?: string}|null
+	 */
+	private $bypass = null;
+
+	/**
 	 * Register the 's3://' stream wrapper
 	 *
 	 * @param S3ClientInterface $client   Client to use with the stream wrapper
@@ -159,6 +165,47 @@ class Stream_Wrapper {
 		$this->initProtocol( $path );
 		$this->params = $this->getBucketKey( $path );
 		$this->mode = rtrim( $mode, 'bt' );
+
+		$this->bypass = File_Bypass::match( $path );
+		if ( $this->bypass ) {
+			$action = $this->bypass['action'];
+			$write_modes = [ 'w', 'a', 'x' ];
+
+			if ( $action === 'local' ) {
+				$local_path = $this->getLocalBypassPath( $path, $this->bypass );
+				if ( $local_path === null ) {
+					return false;
+				}
+				wp_mkdir_p( dirname( $local_path ) );
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen
+				$fh = fopen( $local_path, $this->mode );
+				if ( $fh === false ) {
+					return false;
+				}
+				$this->body = new Stream( $fh );
+				return true;
+			}
+
+			if ( in_array( $this->mode, $write_modes, true ) ) {
+				// void / exists: accept the write but buffer into memory (discarded on flush).
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen
+				$this->body = new Stream( fopen( 'php://memory', 'r+' ) );
+				return true;
+			}
+
+			if ( $this->mode === 'r' ) {
+				if ( $action === 'exists' ) {
+					// Pretend file exists with empty content.
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen
+					$this->body = new Stream( fopen( 'php://memory', 'r+' ) );
+					return true;
+				}
+				// void: file does not exist.
+				return false;
+			}
+
+			return false;
+		}
 
 		$errors = $this->validate( $path, $this->mode );
 		if ( $errors ) {
@@ -212,6 +259,10 @@ class Stream_Wrapper {
 
 		if ( ! $this->body ) {
 			return false;
+		}
+
+		if ( $this->bypass ) {
+			return true;
 		}
 
 		if ( $this->body->isSeekable() ) {
@@ -326,6 +377,22 @@ class Stream_Wrapper {
 	public function unlink( string $path ) : bool {
 		$this->initProtocol( $path );
 
+		/** @psalm-var array{pattern: string, action: string, target?: string}|null $bypass */
+		$bypass = File_Bypass::match( $path );
+		if ( $bypass ) {
+			if ( in_array( $bypass['action'], [ 'void', 'exists' ], true ) ) {
+				return true;
+			}
+			if ( $bypass['action'] === 'local' ) {
+				$local_path = $this->getLocalBypassPath( $path, $bypass );
+				if ( $local_path === null ) {
+					return true;
+				}
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				return ! file_exists( $local_path ) || @unlink( $local_path );
+			}
+		}
+
 		return $this->boolCall(
 			function () use ( $path ) {
 				$this->clearCacheKey( $path );
@@ -357,6 +424,28 @@ class Stream_Wrapper {
 	 */
 	public function url_stat( string $path, int $flags ) {
 		$this->initProtocol( $path );
+
+		/** @psalm-var array{pattern: string, action: string, target?: string}|null $bypass */
+		$bypass = File_Bypass::match( $path );
+
+		if ( $bypass ) {
+			if ( $bypass['action'] === 'void' ) {
+				return false;
+			}
+			if ( $bypass['action'] === 'exists' ) {
+				return $this->getStatTemplate();
+			}
+			if ( $bypass['action'] === 'local' ) {
+				$local_path = $this->getLocalBypassPath( $path, $bypass );
+				if ( $local_path === null ) {
+					return false;
+				}
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				$stat = @stat( $local_path );
+				/** @psalm-var StatArray|false $stat */
+				return $stat !== false ? $stat : false;
+			}
+		}
 
 		$extension = pathinfo( $path, PATHINFO_EXTENSION );
 		/**
@@ -1129,6 +1218,45 @@ class Stream_Wrapper {
 			default:
 				return 'private';
 		}
+	}
+
+	/**
+	 * Map an S3 path to a local filesystem path for a bypass rule with action 'local'.
+	 *
+	 * If the rule defines a 'target' directory, the file's S3 key is appended to it.
+	 * Otherwise, the S3 path is mapped back to the original WordPress upload directory
+	 * by reversing the s3:// ↔ WP_CONTENT_DIR substitution performed in filter_upload_dir().
+	 *
+	 * @param string $s3_path Full S3 path (e.g. s3://bucket/uploads/2024/file.txt).
+	 * @param array  $rule    Bypass rule array (must have action 'local').
+	 * @psalm-param array{pattern: string, action: string, target?: string} $rule
+	 * @return ?string Local filesystem path, or null if it cannot be determined.
+	 */
+	private function getLocalBypassPath( string $s3_path, array $rule ) : ?string {
+		if ( ! empty( $rule['target'] ) ) {
+			$parts = $this->getBucketKey( $s3_path );
+			$key = $parts['Key'] ?? '';
+			return rtrim( (string) $rule['target'], '/' ) . '/' . $key;
+		}
+
+		/** @var Plugin|null */
+		$plugin = $this->getOption( 'plugin' );
+		if ( ! ( $plugin instanceof Plugin ) ) {
+			return null;
+		}
+
+		// Reverse the mapping done by Plugin::filter_upload_dir():
+		//   $dirs['path'] = str_replace( WP_CONTENT_DIR, $s3_path, $dirs['path'] );
+		// So the inverse is: str_replace( $s3_path, WP_CONTENT_DIR, $file_path ).
+		$s3_prefix = $plugin->get_s3_path();
+		$local = str_replace( $s3_prefix, WP_CONTENT_DIR, $s3_path );
+
+		if ( $local === $s3_path ) {
+			// Path was not inside this bucket — cannot map.
+			return null;
+		}
+
+		return $local;
 	}
 
 	/**

--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -9,5 +9,6 @@ Author URI: https://hmn.md
 */
 
 require_once __DIR__ . '/inc/namespace.php';
+require_once __DIR__ . '/inc/class-file-bypass.php';
 
 add_action( 'plugins_loaded', 'S3_Uploads\\init', 0 );

--- a/tests/test-file-bypass.php
+++ b/tests/test-file-bypass.php
@@ -1,0 +1,322 @@
+<?php
+
+use S3_Uploads\File_Bypass;
+
+/**
+ * Tests for the File_Bypass class and the bypass integration in the S3 stream wrapper.
+ *
+ * Bypass rules are configured via the `s3_uploads_bypass_rules` filter in each test so that
+ * PHP constants (which can only be defined once) are not required. File_Bypass::reset() is
+ * called in setUp/tearDown to clear the rule cache between tests.
+ */
+class Test_File_Bypass extends WP_UnitTestCase {
+
+	/** @var string Temporary directory used for 'local' action tests. */
+	private $tmp_dir;
+
+	public function setUp() {
+		parent::setUp();
+		File_Bypass::reset();
+		$this->tmp_dir = sys_get_temp_dir() . '/s3-uploads-bypass-tests-' . uniqid();
+		mkdir( $this->tmp_dir, 0755, true );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		File_Bypass::reset();
+		remove_all_filters( 's3_uploads_bypass_rules' );
+		$this->rmdir_recursive( $this->tmp_dir );
+	}
+
+	// -------------------------------------------------------------------------
+	// File_Bypass::match() — unit tests (no S3 needed)
+	// -------------------------------------------------------------------------
+
+	public function test_match_returns_null_when_no_rules() {
+		$this->assertNull( File_Bypass::match( 's3://tests/image.jpg' ) );
+	}
+
+	public function test_match_returns_rule_on_exact_basename() {
+		add_filter( 's3_uploads_bypass_rules', function() {
+			return [ [ 'pattern' => '.htaccess', 'action' => 'void' ] ];
+		} );
+
+		$rule = File_Bypass::match( 's3://tests/uploads/2024/.htaccess' );
+		$this->assertNotNull( $rule );
+		$this->assertEquals( 'void', $rule['action'] );
+	}
+
+	public function test_match_returns_rule_on_glob_basename() {
+		add_filter( 's3_uploads_bypass_rules', function() {
+			return [ [ 'pattern' => '*.htaccess', 'action' => 'void' ] ];
+		} );
+
+		$rule = File_Bypass::match( 's3://tests/wp-content/uploads/.htaccess' );
+		$this->assertNotNull( $rule );
+		$this->assertEquals( 'void', $rule['action'] );
+	}
+
+	public function test_match_returns_null_for_non_matching_file() {
+		add_filter( 's3_uploads_bypass_rules', function() {
+			return [ [ 'pattern' => '.htaccess', 'action' => 'void' ] ];
+		} );
+
+		$this->assertNull( File_Bypass::match( 's3://tests/uploads/sunflower.jpg' ) );
+	}
+
+	public function test_match_returns_first_matching_rule() {
+		add_filter( 's3_uploads_bypass_rules', function() {
+			return [
+				[ 'pattern' => '*.htaccess', 'action' => 'void' ],
+				[ 'pattern' => '*.htaccess', 'action' => 'exists' ],
+			];
+		} );
+
+		$rule = File_Bypass::match( 's3://tests/.htaccess' );
+		$this->assertEquals( 'void', $rule['action'] );
+	}
+
+	public function test_match_exists_action() {
+		add_filter( 's3_uploads_bypass_rules', function() {
+			return [ [ 'pattern' => 'index.php', 'action' => 'exists' ] ];
+		} );
+
+		$rule = File_Bypass::match( 's3://tests/uploads/index.php' );
+		$this->assertNotNull( $rule );
+		$this->assertEquals( 'exists', $rule['action'] );
+	}
+
+	public function test_match_local_action_with_target() {
+		add_filter( 's3_uploads_bypass_rules', function() {
+			return [ [ 'pattern' => '*.log', 'action' => 'local', 'target' => '/tmp/logs' ] ];
+		} );
+
+		$rule = File_Bypass::match( 's3://tests/uploads/debug.log' );
+		$this->assertNotNull( $rule );
+		$this->assertEquals( 'local', $rule['action'] );
+		$this->assertEquals( '/tmp/logs', $rule['target'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Stream wrapper — void action
+	// -------------------------------------------------------------------------
+
+	public function test_void_write_returns_true_without_hitting_s3() {
+		$this->add_void_rule( '*.htaccess' );
+
+		$path = 's3://' . S3_UPLOADS_BUCKET . '/uploads/.htaccess';
+		$result = file_put_contents( $path, 'deny from all' );
+
+		// file_put_contents returns the number of bytes written (or false on failure).
+		$this->assertNotFalse( $result );
+	}
+
+	public function test_void_file_does_not_exist_in_s3() {
+		$this->add_void_rule( '*.htaccess' );
+
+		$path = 's3://' . S3_UPLOADS_BUCKET . '/uploads/.htaccess';
+		file_put_contents( $path, 'deny from all' );
+
+		$this->assertFalse( file_exists( $path ) );
+	}
+
+	public function test_void_unlink_returns_true() {
+		$this->add_void_rule( '*.htaccess' );
+
+		$path = 's3://' . S3_UPLOADS_BUCKET . '/uploads/.htaccess';
+		$this->assertTrue( unlink( $path ) );
+	}
+
+	public function test_void_read_fails() {
+		$this->add_void_rule( '*.htaccess' );
+
+		$path = 's3://' . S3_UPLOADS_BUCKET . '/uploads/.htaccess';
+		// Reading a void file should fail (file does not exist).
+		$result = @file_get_contents( $path );
+		$this->assertFalse( $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// Stream wrapper — exists action
+	// -------------------------------------------------------------------------
+
+	public function test_exists_file_exists_returns_true_without_writing() {
+		$this->add_exists_rule( 'index.php' );
+
+		$path = 's3://' . S3_UPLOADS_BUCKET . '/uploads/index.php';
+		// File was never written, but the rule makes it appear to exist.
+		$this->assertTrue( file_exists( $path ) );
+	}
+
+	public function test_exists_write_returns_true_without_hitting_s3() {
+		$this->add_exists_rule( 'index.php' );
+
+		$path = 's3://' . S3_UPLOADS_BUCKET . '/uploads/index.php';
+		$result = file_put_contents( $path, '<?php // silence' );
+		$this->assertNotFalse( $result );
+	}
+
+	public function test_exists_file_still_exists_after_write() {
+		$this->add_exists_rule( 'index.php' );
+
+		$path = 's3://' . S3_UPLOADS_BUCKET . '/uploads/index.php';
+		file_put_contents( $path, '<?php // silence' );
+		$this->assertTrue( file_exists( $path ) );
+	}
+
+	public function test_exists_read_returns_empty_content() {
+		$this->add_exists_rule( 'index.php' );
+
+		$path = 's3://' . S3_UPLOADS_BUCKET . '/uploads/index.php';
+		$content = file_get_contents( $path );
+		// File appears to exist with empty content.
+		$this->assertSame( '', $content );
+	}
+
+	public function test_exists_unlink_returns_true() {
+		$this->add_exists_rule( 'index.php' );
+
+		$path = 's3://' . S3_UPLOADS_BUCKET . '/uploads/index.php';
+		$this->assertTrue( unlink( $path ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Stream wrapper — local action with custom target
+	// -------------------------------------------------------------------------
+
+	public function test_local_write_creates_file_in_target_dir() {
+		$this->add_local_rule( '*.log', $this->tmp_dir );
+
+		$path = 's3://' . S3_UPLOADS_BUCKET . '/uploads/debug.log';
+		$result = file_put_contents( $path, 'log entry' );
+		$this->assertNotFalse( $result );
+
+		$expected_local = $this->tmp_dir . '/uploads/debug.log';
+		$this->assertFileExists( $expected_local );
+		$this->assertSame( 'log entry', file_get_contents( $expected_local ) );
+	}
+
+	public function test_local_write_does_not_create_s3_object() {
+		$this->add_local_rule( '*.log', $this->tmp_dir );
+
+		$path = 's3://' . S3_UPLOADS_BUCKET . '/uploads/debug.log';
+		file_put_contents( $path, 'log entry' );
+
+		// The stream wrapper's url_stat for a local file checks the local path, not S3.
+		// To confirm no S3 object was created, bypass the local rule and check via S3.
+		File_Bypass::reset();
+		remove_all_filters( 's3_uploads_bypass_rules' );
+		$this->assertFalse( file_exists( $path ) );
+	}
+
+	public function test_local_read_returns_file_contents() {
+		$this->add_local_rule( '*.log', $this->tmp_dir );
+
+		$path = 's3://' . S3_UPLOADS_BUCKET . '/uploads/debug.log';
+		file_put_contents( $path, 'hello local' );
+
+		// Reset and re-add rule to read back through the stream wrapper.
+		File_Bypass::reset();
+		$this->add_local_rule( '*.log', $this->tmp_dir );
+
+		$content = file_get_contents( $path );
+		$this->assertSame( 'hello local', $content );
+	}
+
+	public function test_local_file_exists_returns_true_when_file_present() {
+		$this->add_local_rule( '*.log', $this->tmp_dir );
+
+		$path = 's3://' . S3_UPLOADS_BUCKET . '/uploads/debug.log';
+		file_put_contents( $path, 'data' );
+
+		File_Bypass::reset();
+		$this->add_local_rule( '*.log', $this->tmp_dir );
+
+		$this->assertTrue( file_exists( $path ) );
+	}
+
+	public function test_local_file_exists_returns_false_when_file_absent() {
+		$this->add_local_rule( '*.log', $this->tmp_dir );
+
+		$path = 's3://' . S3_UPLOADS_BUCKET . '/uploads/missing.log';
+		$this->assertFalse( file_exists( $path ) );
+	}
+
+	public function test_local_unlink_removes_local_file() {
+		$this->add_local_rule( '*.log', $this->tmp_dir );
+
+		$path = 's3://' . S3_UPLOADS_BUCKET . '/uploads/debug.log';
+		file_put_contents( $path, 'data' );
+
+		File_Bypass::reset();
+		$this->add_local_rule( '*.log', $this->tmp_dir );
+
+		$result = unlink( $path );
+		$this->assertTrue( $result );
+
+		$expected_local = $this->tmp_dir . '/uploads/debug.log';
+		$this->assertFileDoesNotExist( $expected_local );
+	}
+
+	public function test_local_creates_nested_directories() {
+		$this->add_local_rule( '*.log', $this->tmp_dir );
+
+		$path = 's3://' . S3_UPLOADS_BUCKET . '/uploads/2024/06/app.log';
+		file_put_contents( $path, 'nested' );
+
+		$expected_local = $this->tmp_dir . '/uploads/2024/06/app.log';
+		$this->assertFileExists( $expected_local );
+	}
+
+	// -------------------------------------------------------------------------
+	// Ensure non-bypassed files are unaffected
+	// -------------------------------------------------------------------------
+
+	public function test_regular_files_are_not_bypassed() {
+		$this->add_void_rule( '*.htaccess' );
+
+		$local_path = dirname( __FILE__ ) . '/data/sunflower.jpg';
+		$remote_path = 's3://' . S3_UPLOADS_BUCKET . '/sunflower-bypass-test.jpg';
+
+		$result = copy( $local_path, $remote_path );
+		$this->assertTrue( $result );
+		$this->assertTrue( file_exists( $remote_path ) );
+
+		// Cleanup.
+		unlink( $remote_path );
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private function add_void_rule( string $pattern ) : void {
+		add_filter( 's3_uploads_bypass_rules', function() use ( $pattern ) {
+			return [ [ 'pattern' => $pattern, 'action' => 'void' ] ];
+		} );
+	}
+
+	private function add_exists_rule( string $pattern ) : void {
+		add_filter( 's3_uploads_bypass_rules', function() use ( $pattern ) {
+			return [ [ 'pattern' => $pattern, 'action' => 'exists' ] ];
+		} );
+	}
+
+	private function add_local_rule( string $pattern, string $target ) : void {
+		add_filter( 's3_uploads_bypass_rules', function() use ( $pattern, $target ) {
+			return [ [ 'pattern' => $pattern, 'action' => 'local', 'target' => $target ] ];
+		} );
+	}
+
+	private function rmdir_recursive( string $dir ) : void {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+		$items = array_diff( scandir( $dir ), [ '.', '..' ] );
+		foreach ( $items as $item ) {
+			$full = $dir . '/' . $item;
+			is_dir( $full ) ? $this->rmdir_recursive( $full ) : unlink( $full );
+		}
+		rmdir( $dir );
+	}
+}


### PR DESCRIPTION
This pull request introduces a robust file bypass system for the S3 Uploads plugin, allowing specific file paths to avoid S3 operations and instead use alternative behaviors (such as pretending files exist, ignoring them, or redirecting to local storage). The changes provide flexible configuration via PHP constants or filters, integrate bypass logic throughout the stream wrapper, and add comprehensive tests for all bypass scenarios.

### Motivation

Some WordPress plugins incorrectly use the `uploads` directory to store operational files such as `.php`, `.htaccess`, `index.php`, or `index.html`. In many cases, these plugins also perform filesystem checks on every request to verify the presence of these files and recreate them if they are missing.

When the `uploads` directory is backed by S3 via the stream wrapper, these behaviors can trigger unnecessary remote operations or cause compatibility issues, since these files are not intended to be stored in object storage.

This feature introduces a bypass mechanism that allows these specific files or paths to avoid S3 interactions entirely, preventing excessive remote calls while maintaining compatibility with plugins that expect traditional filesystem semantics.

### File bypass system implementation

* Added the new `File_Bypass` class in `inc/class-file-bypass.php`, which defines and manages file bypass rules, supporting three actions: `void`, `exists`, and `local`. Rules can be configured via PHP constants or the `s3_uploads_bypass_rules` filter.
* Integrated the bypass system into the S3 stream wrapper (`inc/class-stream-wrapper.php`), so file operations (open, write, unlink, stat) respect bypass rules and perform the appropriate action (ignore, pretend, or redirect to local filesystem). [[1]](diffhunk://#diff-c2755e463e335dafccedeb5b866b10d7cec4661d71d622b59f3cb0007a7ad43dR112-R117) [[2]](diffhunk://#diff-c2755e463e335dafccedeb5b866b10d7cec4661d71d622b59f3cb0007a7ad43dR169-R209) [[3]](diffhunk://#diff-c2755e463e335dafccedeb5b866b10d7cec4661d71d622b59f3cb0007a7ad43dR264-R267) [[4]](diffhunk://#diff-c2755e463e335dafccedeb5b866b10d7cec4661d71d622b59f3cb0007a7ad43dR380-R395) [[5]](diffhunk://#diff-c2755e463e335dafccedeb5b866b10d7cec4661d71d622b59f3cb0007a7ad43dR428-R449) [[6]](diffhunk://#diff-c2755e463e335dafccedeb5b866b10d7cec4661d71d622b59f3cb0007a7ad43dR1223-R1261)

### Testing and validation

* Added a comprehensive test suite in `tests/test-file-bypass.php` to verify all bypass behaviors (`void`, `exists`, `local`) and ensure regular files are unaffected. Tests cover matching logic, file existence, read/write/unlink operations, and directory creation for local bypasses.
