### PR TITLE
Add missing export-ignore entries to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,12 @@
-/tests export-ignore
-/bin export-ignore
-/.gitignore export-ignore
-/.travis.yml export-ignore
+/.gitattributes  export-ignore
+/.github         export-ignore
+/.gitignore      export-ignore
+/.phpcsignore    export-ignore
+/.travis.yml     export-ignore
+/bin             export-ignore
+/codecov.yml     export-ignore
+/composer.lock   export-ignore
 /phpunit.xml.dist export-ignore
+/psalm           export-ignore
+/psalm.xml       export-ignore
+/tests           export-ignore


### PR DESCRIPTION
## Problem

Consumers installing this plugin via Composer (the recommended install path since v3) end up with dev-only files in their `plugins/s3-uploads/` directory. The current `.gitattributes` only filters a handful of paths:

```
/tests export-ignore
/bin export-ignore
/.gitignore export-ignore
/.travis.yml export-ignore
/phpunit.xml.dist export-ignore
```

Several dev paths have been added to the repo since `.gitattributes` was last updated and are not filtered. After `composer install`, the plugin folder contains:

```
plugins/s3-uploads/
├── .github/         ← GitHub Actions workflows + hmlinter config
├── psalm/           ← Psalm stubs directory
├── psalm.xml        ← Psalm config
├── codecov.yml      ← Codecov config
├── .phpcsignore     ← PHPCS config
├── .gitattributes   ← (this file)
├── composer.lock    ← Lock from this repo, irrelevant to consumers
└── ... (runtime files)
```

For a comparison — well-maintained Composer packages like `symfony/*`, `guzzlehttp/*`, `aws/aws-sdk-php` all keep their dist archives clean of CI / static-analysis / coverage configs through `.gitattributes`. WordPress plugins less so, but since v3 is Composer-only it's worth aligning.

## Change

Adds `export-ignore` entries for:

- `/.github` — CI workflows
- `/.gitattributes` — the file itself (conventional)
- `/.phpcsignore` — phpcs config
- `/codecov.yml` — codecov config
- `/composer.lock` — lock file, only relevant in this repo
- `/psalm` — Psalm stubs directory
- `/psalm.xml` — Psalm config

The full list is also re-sorted alphabetically and column-aligned for readability. No existing entries are removed (including the now-stale `/.travis.yml` — happy to drop it in a follow-up if you prefer).

## Effect

After the next tagged release, `composer install humanmade/s3-uploads` will produce a `plugins/s3-uploads/` directory that contains only runtime files (`s3-uploads.php`, `inc/`, `composer.json`, `verify.txt`, `README.md`, `LICENSE`, `CHANGELOG.md`). The GitHub-generated archive zip for the tag will also be ~30% smaller.

## Verification

`git archive` honors `export-ignore` the same way GitHub's auto-generated tag archives do. Local check on this branch:

```
git archive --format=tar HEAD | tar -t | sort
```

Lists only runtime files; no `.github/`, `psalm/`, `codecov.yml`, etc.