### PR TITLE
Fix get_s3_location_for_url() to match regional S3 hostnames

### DIFF
--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -278,8 +278,9 @@ class Plugin {
 	 * @return array{bucket: string, key: string, query: string|null}|null
 	 */
 	public function get_s3_location_for_url( string $url ) : ?array {
-		$s3_url = 'https://' . $this->get_s3_bucket() . '.s3.amazonaws.com/';
-		if ( strpos( $url, $s3_url ) === 0 ) {
+		// Match both legacy (bucket.s3.amazonaws.com) and regional (bucket.s3.{region}.amazonaws.com) hostnames.
+		$s3_pattern = '#^https?://' . preg_quote( $this->get_s3_bucket(), '#' ) . '\.s3(?:\.[a-z0-9-]+)?\.amazonaws\.com/#i';
+		if ( preg_match( $s3_pattern, $url ) ) {
 			$parsed = wp_parse_url( $url );
 			return [
 				'bucket' => $this->get_s3_bucket(),

--- a/tests/test-s3-uploads.php
+++ b/tests/test-s3-uploads.php
@@ -173,6 +173,17 @@ class Test_S3_Uploads extends WP_UnitTestCase {
 		$this->assertEquals( 'hmn-uploads', $uploads->get_s3_bucket() );
 	}
 
+	function test_get_s3_location_for_url_regional_hostname() {
+		$uploads = new S3_Uploads\Plugin( 'hmn-uploads', S3_UPLOADS_KEY, S3_UPLOADS_SECRET, null, 'us-west-2' );
+
+		// Regional hostnames (bucket.s3.{region}.amazonaws.com) must resolve correctly.
+		$regional_url = 'https://hmn-uploads.s3.us-west-2.amazonaws.com/2024/01/image.jpg';
+		$location     = $uploads->get_s3_location_for_url( $regional_url );
+		$this->assertNotNull( $location, 'Regional S3 hostname should be recognised by get_s3_location_for_url()' );
+		$this->assertEquals( 'hmn-uploads', $location['bucket'] );
+		$this->assertEquals( '2024/01/image.jpg', $location['key'] );
+	}
+
 	function test_wp_unique_filename() {
 		S3_Uploads\Plugin::get_instance()->setup();
 		$upload_dir = wp_upload_dir();


### PR DESCRIPTION
## Problem

\`get_s3_location_for_url()\` only matches the legacy global S3 hostname:

\`\`\`php
\$s3_url = 'https://' . \$this->get_s3_bucket() . '.s3.amazonaws.com/';
if ( strpos( \$url, \$s3_url ) === 0 ) { ... }
\`\`\`

AWS's current recommended hostname form for any configured region is \`bucket.s3.{region}.amazonaws.com\`. When S3 Uploads is configured with a non-\`us-east-1\` region, the AWS SDK generates signed private attachment URLs using the regional hostname. The method returns \`null\` for those URLs, so \`add_s3_signed_params_to_attachment_url()\` passes them through unsigned — breaking private attachment access on regionally-configured installs.

This is the issue described in #746.

## Fix

Replace the \`strpos()\` prefix check with a regex that matches both the legacy and regional hostname forms:

\`\`\`php
\$s3_pattern = '#^https?://' . preg_quote( \$this->get_s3_bucket(), '#' ) . '\.s3(?:\.[a-z0-9-]+)?\.amazonaws\.com/#i';
if ( preg_match( \$s3_pattern, \$url ) ) { ... }
\`\`\`

The optional \`(?:\.[a-z0-9-]+)?\` group matches the region segment when present and is absent for the legacy global endpoint — so both \`bucket.s3.amazonaws.com\` and \`bucket.s3.us-west-2.amazonaws.com\` work correctly.

## Test

Added \`test_get_s3_location_for_url_regional_hostname()\` asserting that a \`us-west-2\` regional URL resolves to the correct bucket and key.

---

*Developed with AI assistance (GitHub Copilot + Claude) for code review; the fix, test, and description are my own.*