### PR TITLE
Return filesize from Image_Editor_Imagick::_save()

### DIFF
--- a/inc/class-image-editor-imagick.php
+++ b/inc/class-image-editor-imagick.php
@@ -78,7 +78,7 @@ class Image_Editor_Imagick extends WP_Image_Editor_Imagick {
 	 * @param Imagick $image
 	 * @param ?string $filename
 	 * @param ?string $mime_type
-	 * @return WP_Error|array{path: string, file: string, width: int, height: int, mime-type: string}
+	 * @return WP_Error|array{path: string, file: string, width: int, height: int, mime-type: string, filesize: int}
 	 */
 	protected function _save( $image, $filename = null, $mime_type = null ) {
 		list( $filename, $extension, $mime_type ) = $this->get_output_format( $filename, $mime_type );
@@ -96,7 +96,7 @@ class Image_Editor_Imagick extends WP_Image_Editor_Imagick {
 		}
 
 		/**
-		 * @var WP_Error|array{path: string, file: string, width: int, height: int, mime-type: string}
+		 * @var WP_Error|array{path: string, file: string, width: int, height: int, mime-type: string, filesize: int}
 		 */
 		$parent_call = parent::_save( $image, $temp_filename !== false ? $temp_filename : $filename, $mime_type );
 
@@ -127,6 +127,7 @@ class Image_Editor_Imagick extends WP_Image_Editor_Imagick {
 			'width'     => $this->size['width'] ?? 0,
 			'height'    => $this->size['height'] ?? 0,
 			'mime-type' => $mime_type,
+			'filesize'  => $save['filesize'] ?? wp_filesize( $filename ),
 		];
 
 		return $response;


### PR DESCRIPTION
Fixes #750.

`Image_Editor_Imagick::_save()` rebuilds its response array after copying the temp file to S3, but omits the `filesize` key that `WP_Image_Editor::_save()` has returned since WP 6.0 ([core ticket #49412](https://core.trac.wordpress.org/ticket/49412)).

As a result:

- saves from the media library image editor (`wp_save_image()`) trigger an "Undefined array key" PHP warning and persist attachment meta without a usable `filesize`;
- `sizes[*]['filesize']` is missing from attachment meta for all sub-sizes on every upload;
- code paths that read the value fall back to remote `filesize()` stats against S3 — the slow HEAD requests #492 / #493 aimed to eliminate (the #493 backfill hooks `wp_generate_attachment_metadata`, which never fires on the image-editor save path).

This change returns the `filesize` that `parent::_save()` already computed for the local temp file — byte-identical to the object copied to S3, so no extra remote request is made. The `wp_filesize()` fallback only applies if a future WP version stops returning the key. Docblocks updated to match.
